### PR TITLE
feat: add @KNMethodRetPromise supports async method

### DIFF
--- a/knoi/docs/function-zh.md
+++ b/knoi/docs/function-zh.md
@@ -47,3 +47,52 @@ import { invoke } from "@kuiklybase/knoi"
 let result: String = invoke<String>("testStringReturnString", "input")
 console.log("invoke testStringReturnString result " + result);
 ```
+
+##### 导出 `retPromise` 方法
+
+当 ArkTS 侧需要拿到 `Promise` 时，使用 `@KNExportRetPromise`，而不是 `@KNExport`。ArkTS 侧应通过 `invokeRetPromise<R>(...)` 调用这类方法，而不是 `invoke<R>(...)`。
+
+示例来自 `example/sample/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/ArkTs2KNBenchmark.kt`：
+
+```Kotlin
+@KNExportRetPromise
+fun testAsyncIntReturnInt(number: Int): Int {
+    return number + 100
+}
+
+@KNExportRetPromise
+fun testAsyncVoidReturnJSValue(): JSValue = runBlocking {
+    val ownerTid = getCurrentAsyncInvokeOwnerTid() ?: getTid()
+    val ioScope = CoroutineScope(Dispatchers.IO)
+    ioScope.async {
+        val result = JSValue.createJSObject(tid = ownerTid)
+        result["type"] = JSValue.createJSValue("async-void-jsvalue", tid = ownerTid)
+        result["ownerTid"] = JSValue.createJSValue(ownerTid, tid = ownerTid)
+        result
+    }.await()
+}
+
+@KNExportRetPromise
+@OptIn(ExperimentalForeignApi::class)
+fun testAsyncArrayBufferReturnArrayBuffer(buffer: ArrayBuffer): ArrayBuffer {
+    info("testAsyncArrayBufferReturnArrayBuffer")
+    buffer.getData<uint8_tVar>()?.set(0, 9u)
+    return buffer
+}
+```
+
+规格说明：
+
+- 只有标注了 `@KNExportRetPromise` 的函数，才会被导出为 Promise 返回的方法。
+- `@KNExportRetPromise(name = "...")` 的 `name` 参数与 `@KNExport` 使用相同的注册规则。
+- 生成后的 ArkTS 签名会变为 `Promise<R>`。例如 `Int -> Promise<number>`、`Unit -> Promise<void>`、`ArrayBuffer -> Promise<ArrayBuffer>`。
+- 异步参数和返回值支持的类型为 `Unit`、`Boolean`、`Int`、`String`、`Double`、`Long`、`Array`、`Function`、`List`、`ArrayList`、`Map`、`HashMap`、`JSValue`、`ArrayBuffer`。
+- 异步导出的类型校验是递归的。`Array`、`List`、`ArrayList`、`Map`、`HashMap` 只有在元素类型同样受支持时才可使用。
+- Kotlin 抛出的异常会在 ArkTS 侧表现为 `Promise reject`。
+- 异步函数返回的 `JSValue`，以及容器中的嵌套 `JSValue`，必须保持在发起调用的 JS 线程上。如果在异步任务里构造 `JSValue`，需要像 `testAsyncVoidReturnJSValue()` 一样使用调用方 owner tid。
+
+不支持的场景：
+
+- 不支持未纳入转换集合的参数或返回值类型，例如 `KClass`，或未被支持的自定义类。
+- 不支持在 `ohosArm64` 之外使用 `@KNExportRetPromise`；异步导出代码生成仅在 Harmony `ohosArm64` 目标启用。
+- 不支持返回在其他 JS 线程创建的 `JSValue`；此时运行时会将 `Promise` 置为 reject。

--- a/knoi/docs/function.md
+++ b/knoi/docs/function.md
@@ -46,3 +46,52 @@ import { invoke } from "@kuiklybase/knoi"
 let result: String = invoke<String>("testStringReturnString", "input")
 console.log("invoke testStringReturnString result " + result);
 ```
+
+##### `retPromise` for Exported Functions
+
+Use `@KNExportRetPromise` when ArkTS should receive a `Promise` instead of a synchronous return value. On the ArkTS side, call these methods with `invokeRetPromise<R>(...)`, not `invoke<R>(...)`.
+
+Examples from `example/sample/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/ArkTs2KNBenchmark.kt`:
+
+```Kotlin
+@KNExportRetPromise
+fun testAsyncIntReturnInt(number: Int): Int {
+    return number + 100
+}
+
+@KNExportRetPromise
+fun testAsyncVoidReturnJSValue(): JSValue = runBlocking {
+    val ownerTid = getCurrentAsyncInvokeOwnerTid() ?: getTid()
+    val ioScope = CoroutineScope(Dispatchers.IO)
+    ioScope.async {
+        val result = JSValue.createJSObject(tid = ownerTid)
+        result["type"] = JSValue.createJSValue("async-void-jsvalue", tid = ownerTid)
+        result["ownerTid"] = JSValue.createJSValue(ownerTid, tid = ownerTid)
+        result
+    }.await()
+}
+
+@KNExportRetPromise
+@OptIn(ExperimentalForeignApi::class)
+fun testAsyncArrayBufferReturnArrayBuffer(buffer: ArrayBuffer): ArrayBuffer {
+    info("testAsyncArrayBufferReturnArrayBuffer")
+    buffer.getData<uint8_tVar>()?.set(0, 9u)
+    return buffer
+}
+```
+
+Specification:
+
+- Only functions annotated with `@KNExportRetPromise` are exported as Promise-returning functions.
+- `name` on `@KNExportRetPromise(name = "...")` follows the same registration rule as `@KNExport`.
+- The generated ArkTS signature becomes `Promise<R>`. For example, `Int -> Promise<number>`, `Unit -> Promise<void>`, and `ArrayBuffer -> Promise<ArrayBuffer>`.
+- Supported async parameter and return types are `Unit`, `Boolean`, `Int`, `String`, `Double`, `Long`, `Array`, `Function`, `List`, `ArrayList`, `Map`, `HashMap`, `JSValue`, and `ArrayBuffer`.
+- Async export type checking is recursive. `Array`, `List`, `ArrayList`, `Map`, and `HashMap` are supported only when their element types are also supported.
+- Thrown Kotlin exceptions reject the ArkTS `Promise`.
+- `JSValue` and nested `JSValue` values returned from async functions must stay on the invoking JS thread. If you construct a `JSValue` inside async work, use the invoking owner tid as shown in `testAsyncVoidReturnJSValue()`.
+
+Not supported:
+
+- Unsupported parameter or return types, such as `KClass` or arbitrary custom classes that are not in the supported conversion set.
+- Using `@KNExportRetPromise` outside `ohosArm64`; async export code generation is only enabled for the Harmony `ohosArm64` target.
+- Returning a `JSValue` created on a different JS thread; runtime will reject the `Promise` in this case.

--- a/knoi/docs/service-zh.md
+++ b/knoi/docs/service-zh.md
@@ -71,6 +71,54 @@ getTestServiceB().method1("param1")
 getService<TestServiceB>("TestServiceB").method1("param1")
 ```
 
+##### ServiceProvider `retPromise` 方法
+
+当 Kotlin 服务方法需要以 `Promise<R>` 的形式暴露给 ArkTS 时，请在该方法上标注 `@KNMethodRetPromise`。如果服务是基于接口实现的，可以把注解标在接口方法上，处理器会沿 override 链识别它。
+
+示例来自 `example/sample-api/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/TestServiceBApi.kt` 与 `example/sample/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/TestServiceB.kt`：
+
+```Kotlin
+interface TestServiceBApi {
+    @KNMethodRetPromise
+    fun methodWithPromiseString(a: String): String
+
+    @KNMethodRetPromise
+    fun methodWithPromiseJSValueReturnJSValue(a: JSValue): JSValue
+
+    @KNMethodRetPromise
+    fun methodWithPromiseUnitReturnJSValue(): JSValue
+
+    @KNMethodRetPromise
+    fun methodWithPromiseArrayBufferReturnArrayBuffer(buffer: ArrayBuffer): ArrayBuffer
+
+    @KNMethodRetPromise
+    fun methodWithPromiseMapReturnMap(map: Map<String, Any?>): Map<String, Any?>
+}
+
+@ServiceProvider(bind = TestServiceBApi::class, singleton = false)
+open class TestServiceB : TestServiceBApi {
+    override fun methodWithPromiseString(a: String): String {
+        return "$a promise modify from KMM"
+    }
+}
+```
+
+规格说明：
+
+- 只有标注了 `@KNMethodRetPromise` 的方法会被导出为 Promise 返回的服务方法；未标注的方法仍然保持同步调用。
+- 生成后的 ArkTS 服务接口会将这些方法的签名从 `R` 自动改为 `Promise<R>`。
+- 支持 override 链追踪。对基于接口的服务，只标注接口方法即可。
+- 异步参数和返回值支持的类型为 `Unit`、`Boolean`、`Int`、`String`、`Double`、`Long`、`Array`、`Function`、`List`、`ArrayList`、`Map`、`HashMap`、`JSValue`、`ArrayBuffer`。
+- 异步服务方法的类型校验与异步导出函数一致，按相同的受支持类型集合做递归校验。
+- Kotlin 抛出的异常会在 ArkTS 侧表现为 `Promise reject`。
+- 异步服务方法返回的 `JSValue`，以及容器中的嵌套 `JSValue`，必须保持在发起调用的 JS 线程上。
+
+不支持的场景：
+
+- 不支持未纳入转换集合的参数或返回值类型，例如 `KClass`，或未被支持的自定义类。
+- 未标注 `@KNMethodRetPromise` 却期望生成 Promise 调用；处理器会继续按同步方法处理。
+- 不支持返回在其他 JS 线程创建的 `JSValue`；此时运行时会将 `Promise` 置为 reject。
+
 ### 详细例子🌰
 
 ##### Kotlin 调用 ArkTS 

--- a/knoi/docs/service.md
+++ b/knoi/docs/service.md
@@ -70,6 +70,54 @@ getTestServiceB().method1("param1")
 getService<TestServiceB>("TestServiceB").method1("param1")
 ```
 
+##### `retPromise` for ServiceProvider Methods
+
+When a Kotlin service method should be exposed to ArkTS as `Promise<R>`, mark that method with `@KNMethodRetPromise`. If the service implements an interface, the annotation can be placed on the interface method and the processor will track it through overrides.
+
+Examples from `example/sample-api/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/TestServiceBApi.kt` and `example/sample/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/TestServiceB.kt`:
+
+```Kotlin
+interface TestServiceBApi {
+    @KNMethodRetPromise
+    fun methodWithPromiseString(a: String): String
+
+    @KNMethodRetPromise
+    fun methodWithPromiseJSValueReturnJSValue(a: JSValue): JSValue
+
+    @KNMethodRetPromise
+    fun methodWithPromiseUnitReturnJSValue(): JSValue
+
+    @KNMethodRetPromise
+    fun methodWithPromiseArrayBufferReturnArrayBuffer(buffer: ArrayBuffer): ArrayBuffer
+
+    @KNMethodRetPromise
+    fun methodWithPromiseMapReturnMap(map: Map<String, Any?>): Map<String, Any?>
+}
+
+@ServiceProvider(bind = TestServiceBApi::class, singleton = false)
+open class TestServiceB : TestServiceBApi {
+    override fun methodWithPromiseString(a: String): String {
+        return "$a promise modify from KMM"
+    }
+}
+```
+
+Specification:
+
+- Only methods marked with `@KNMethodRetPromise` are exported as Promise-returning service methods; unmarked methods remain synchronous.
+- Generated ArkTS service interfaces change the marked method signatures from `R` to `Promise<R>`.
+- Override lookup is supported. For interface-based services, annotating the interface method is sufficient.
+- Supported async parameter and return types are `Unit`, `Boolean`, `Int`, `String`, `Double`, `Long`, `Array`, `Function`, `List`, `ArrayList`, `Map`, `HashMap`, `JSValue`, and `ArrayBuffer`.
+- Async service type checking uses the same recursive supported-type set as async exported functions.
+- Kotlin exceptions reject the returned `Promise`.
+- `JSValue` and nested `JSValue` values returned from async service methods must remain on the invoking JS thread.
+
+Not supported:
+
+- Unsupported parameter or return types, such as `KClass` or arbitrary custom classes that are not in the supported conversion set.
+- Expecting Promise behavior without `@KNMethodRetPromise`; the processor will keep that method synchronous.
+- Returning a `JSValue` created on a different JS thread; runtime will reject the `Promise` in this case.
+
 ### Detailed Examples 🌰
 
 ##### Kotlin Calling ArkTS

--- a/knoi/example/sample-api/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/TestServiceBApi.kt
+++ b/knoi/example/sample-api/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/TestServiceBApi.kt
@@ -1,6 +1,7 @@
 package com.tencent.tmm.knoi.sample
 
 import com.tencent.tmm.knoi.annotation.Hidden
+import com.tencent.tmm.knoi.annotation.KNMethodRetPromise
 import com.tencent.tmm.knoi.type.ArrayBuffer
 import com.tencent.tmm.knoi.type.JSValue
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -41,6 +42,18 @@ interface TestServiceBApi {
     // 无参数调用
     fun methodWithUnit()
 
+    // Promise 基础类型
+    @KNMethodRetPromise
+    fun methodWithPromiseString(a: String): String
+
+    // Promise JSValue 输入输出
+    @KNMethodRetPromise
+    fun methodWithPromiseJSValueReturnJSValue(a: JSValue): JSValue
+
+    // Promise 无参数返回 JSValue
+    @KNMethodRetPromise
+    fun methodWithPromiseUnitReturnJSValue(): JSValue
+
     // 传入任意 JS 类型，返回任意 JS 类型
     fun methodWithJSValueReturnJSValue(a: JSValue): JSValue
 
@@ -48,10 +61,19 @@ interface TestServiceBApi {
     @OptIn(ExperimentalForeignApi::class)
     fun methodWithArrayBufferReturnArrayBuffer(buffer: ArrayBuffer): ArrayBuffer
 
+    // Promise 二进制数据输入输出
+    @OptIn(ExperimentalForeignApi::class)
+    @KNMethodRetPromise
+    fun methodWithPromiseArrayBufferReturnArrayBuffer(buffer: ArrayBuffer): ArrayBuffer
+
     // 多参数
     fun method3Params(a: String, b: Int, c: JSValue): JSValue
 
     fun methodWithMultiTypeMap(map: Map<String, Any?>): Map<String, Any?>
+
+    // Promise Map 容器类型输入输出
+    @KNMethodRetPromise
+    fun methodWithPromiseMapReturnMap(map: Map<String, Any?>): Map<String, Any?>
 
     fun methodWithDefaultValueInSubType(a: Int = 42, b: String = "default value in sub type")
 

--- a/knoi/example/sample/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/TestServiceB.kt
+++ b/knoi/example/sample/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/sample/TestServiceB.kt
@@ -1,9 +1,11 @@
 package com.tencent.tmm.knoi.sample
 
 import com.tencent.tmm.knoi.annotation.Hidden
+import com.tencent.tmm.knoi.getCurrentAsyncInvokeOwnerTid
 import com.tencent.tmm.knoi.annotation.ServiceProvider
 import com.tencent.tmm.knoi.converter.ktValueToJSValue
 import com.tencent.tmm.knoi.getEnv
+import com.tencent.tmm.knoi.getTid
 import com.tencent.tmm.knoi.logger.info
 import com.tencent.tmm.knoi.type.ArrayBuffer
 import com.tencent.tmm.knoi.type.JSValue
@@ -101,6 +103,37 @@ open class TestServiceB : TestServiceBApi {
         info("TestServiceB methodWithUnit")
     }
 
+    // Promise 基础类型
+    override fun methodWithPromiseString(a: String): String {
+        info("TestServiceB methodWithPromiseString")
+        return "$a promise modify from KMM"
+    }
+
+    // Promise JSValue 输入输出
+    override fun methodWithPromiseJSValueReturnJSValue(a: JSValue): JSValue {
+        info("TestServiceB methodWithPromiseJSValueReturnJSValue")
+        val tid = a.tid
+        val result = JSValue.createJSObject(tid = tid)
+        result["original"] = a
+        result["type"] = JSValue.createJSValue("service-async-jsvalue", tid = tid)
+        result["message"] = JSValue.createJSValue("processed in Promise service method", tid = tid)
+        if (a.isObject() && !a.isArrayType() && !a.isArrayBuffer()) {
+            result["name"] = JSValue.createJSValue(a["name"]?.toKString().orEmpty() + "-service", tid = tid)
+        }
+        return result
+    }
+
+    // Promise 无参数返回 JSValue
+    override fun methodWithPromiseUnitReturnJSValue(): JSValue {
+        info("TestServiceB methodWithPromiseUnitReturnJSValue")
+        val ownerTid = getCurrentAsyncInvokeOwnerTid() ?: getTid()
+        val result = JSValue.createJSObject(tid = ownerTid)
+        result["type"] = JSValue.createJSValue("service-async-no-input-jsvalue", tid = ownerTid)
+        result["ownerTid"] = JSValue.createJSValue(ownerTid, tid = ownerTid)
+        result["message"] = JSValue.createJSValue("created from Promise service method", tid = ownerTid)
+        return result
+    }
+
     // 传入任意 JS 类型，返回任意 JS 类型
     override fun methodWithJSValueReturnJSValue(a: JSValue): JSValue {
         val arrayJSValue = a["array"]
@@ -125,6 +158,18 @@ open class TestServiceB : TestServiceBApi {
         return buffer
     }
 
+    // Promise 二进制数据输入输出
+    @OptIn(ExperimentalForeignApi::class)
+    override fun methodWithPromiseArrayBufferReturnArrayBuffer(buffer: ArrayBuffer): ArrayBuffer {
+        info("knoi-sample methodWithPromiseArrayBufferReturnArrayBuffer")
+        val bufferArray = buffer.getData<uint8_tVar>()
+        bufferArray?.set(0, 9u)
+        bufferArray?.set(1, 8u)
+        bufferArray?.set(2, 7u)
+        bufferArray?.set(3, 6u)
+        return buffer
+    }
+
     // 多参数
     override fun method3Params(a: String, b: Int, c: JSValue): JSValue {
         return c
@@ -136,6 +181,14 @@ open class TestServiceB : TestServiceBApi {
         var function = map["callback"] as (Array<JSValue>) -> String
         var obj = map["object"] as Map<String, *>
         return map
+    }
+
+    // Promise Map 容器类型输入输出
+    override fun methodWithPromiseMapReturnMap(map: Map<String, Any?>): Map<String, Any?> {
+        val result = map.toMutableMap()
+        result["promiseProcessed"] = true
+        result["source"] = "TestServiceB"
+        return result
     }
 
     override fun methodWithDefaultValueInSubType(a: Int, b: String) {

--- a/knoi/knoi-annotation/src/commonMain/kotlin/com/tencent/tmm/knoi/annotation/Annotations.kt
+++ b/knoi/knoi-annotation/src/commonMain/kotlin/com/tencent/tmm/knoi/annotation/Annotations.kt
@@ -10,6 +10,9 @@ annotation class KNExport(val name: String = "")
 @Target(AnnotationTarget.FUNCTION)
 annotation class KNExportRetPromise(val name: String = "")
 
+@Target(AnnotationTarget.FUNCTION)
+annotation class KNMethodRetPromise()
+
 @Target(AnnotationTarget.CLASS)
 annotation class ServiceConsumer(val name: String = "")
 

--- a/knoi/knoi-annotation/src/commonMain/kotlin/com/tencent/tmm/knoi/service/Invokable.kt
+++ b/knoi/knoi-annotation/src/commonMain/kotlin/com/tencent/tmm/knoi/service/Invokable.kt
@@ -5,6 +5,8 @@ import kotlin.reflect.KClass
 interface Invokable {
     fun invoke(name: String, vararg params: Any?): Any?
 
+    fun isRetPromise(method: String): Boolean = false
+
     fun getReturnType(method: String): KClass<out Any>
 
     fun getParamsTypeList(method: String): Array<KClass<out Any>>

--- a/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/function/Function.kt
+++ b/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/function/Function.kt
@@ -11,7 +11,8 @@ data class FunctionInfo(
     val packageName: String,
     val functionName: String,
     val parameters: List<Param>,
-    val returnType: KSType?
+    val returnType: KSType?,
+    val retPromise: Boolean = false
 ) {
     override fun toString(): String {
         return "ExportFunction(packageName='$packageName', functionName='$functionName', parameters=$parameters, returnType='$returnType')"

--- a/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/function/FunctionListHelper.kt
+++ b/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/function/FunctionListHelper.kt
@@ -6,7 +6,10 @@ import com.tencent.tmm.knoi.annotation.Hidden
 import com.tencent.tmm.knoi.service.ignoreFunctionList
 import com.tencent.tmm.knoi.service.parseFunctionInfo
 
-fun parseFunctionsList(ksClassDeclaration: KSClassDeclaration): List<FunctionInfo> {
+fun parseFunctionsList(
+    ksClassDeclaration: KSClassDeclaration,
+    trackMethodRetPromise: Boolean = false
+): List<FunctionInfo> {
     val genFunctionList = ksClassDeclaration.getAllFunctions().filter { ksFunctionDeclaration ->
         !ignoreFunctionList.contains<String>(
             ksFunctionDeclaration.simpleName.asString()
@@ -17,7 +20,7 @@ fun parseFunctionsList(ksClassDeclaration: KSClassDeclaration): List<FunctionInf
         )
     }
     val functionList = genFunctionList.map { ksFunctionDeclaration ->
-        parseFunctionInfo(ksFunctionDeclaration)
+        parseFunctionInfo(ksFunctionDeclaration, trackMethodRetPromise)
     }.toList()
     return functionList
 }

--- a/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/service/SerivceProcessorHelper.kt
+++ b/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/service/SerivceProcessorHelper.kt
@@ -12,6 +12,8 @@ import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.toTypeName
+import com.tencent.tmm.knoi.annotation.KNMethodRetPromise
+import com.tencent.tmm.knoi.annotation.ServiceProvider
 import com.tencent.tmm.knoi.function.FunctionInfo
 import com.tencent.tmm.knoi.function.Param
 import com.tencent.tmm.knoi.function.parseFunctionsList
@@ -87,16 +89,37 @@ fun parseServiceInfoList(resolver: Resolver, annotationKClass: KClass<out Any>):
         val isSingleton = getAnnotationValueByKey(it, annotationName, "singleton", false)
         val bind: KSType? = getAnnotationValueByKey(it, annotationName, "bind", null)
 
+        val functionList = parseFunctionsList(
+            it,
+            trackMethodRetPromise = annotationKClass == ServiceProvider::class
+        )
         val serviceInfo = ServiceInfo(
-            serviceName, it.asStarProjectedType(), packageName, parseFunctionsList(it), it, isSingleton, bind
+            serviceName, it.asStarProjectedType(), packageName, functionList, it, isSingleton, bind
         )
         serviceInfos.add(serviceInfo)
     }
     return serviceInfos
 }
 
+private fun hasMethodRetPromise(functionDeclaration: KSFunctionDeclaration): Boolean {
+    val annotationName = KNMethodRetPromise::class.qualifiedName!!
+    var currentDeclaration: KSFunctionDeclaration? = functionDeclaration
+    while (currentDeclaration != null) {
+        val hasAnnotation = currentDeclaration.annotations.any { annotation ->
+            annotation.annotationType.resolve().declaration.qualifiedName?.asString() == annotationName
+        }
+        if (hasAnnotation) {
+            return true
+        }
+        currentDeclaration = currentDeclaration.findOverridee() as? KSFunctionDeclaration
+    }
+    return false
+}
 
-fun parseFunctionInfo(functionDeclaration: KSFunctionDeclaration): FunctionInfo {
+fun parseFunctionInfo(
+    functionDeclaration: KSFunctionDeclaration,
+    trackMethodRetPromise: Boolean = false
+): FunctionInfo {
     val functionName = functionDeclaration.simpleName.asString()
     val parameterList = mutableListOf<Param>()
     functionDeclaration.parameters.forEachIndexed { index, parameter ->
@@ -115,7 +138,9 @@ fun parseFunctionInfo(functionDeclaration: KSFunctionDeclaration): FunctionInfo 
         packageName,
         functionName,
         parameterList,
-        functionDeclaration.returnType?.let { getRealKSType(it) })
+        functionDeclaration.returnType?.let { getRealKSType(it) },
+        retPromise = trackMethodRetPromise && hasMethodRetPromise(functionDeclaration)
+    )
 }
 
 fun getKTTypeName(returnType: KSType?, toClassName: Boolean = true): TypeName {

--- a/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/service/ServiceProviderProcessor.kt
+++ b/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/service/ServiceProviderProcessor.kt
@@ -4,6 +4,7 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.Modifier
 import com.squareup.kotlinpoet.ANY
+import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.INT
@@ -22,6 +23,7 @@ import com.tencent.tmm.knoi.function.Param
 import com.tencent.tmm.knoi.utils.isOhosArm64
 import com.tencent.tmm.knoi.utils.OPTION_MODULE_NAME
 import com.tencent.tmm.knoi.utils.capitalizeName
+import com.tencent.tmm.knoi.utils.checkAsyncServiceSupportType
 import com.tencent.tmm.knoi.utils.checkFunctionSupportType
 import kotlin.reflect.KClass
 
@@ -32,6 +34,7 @@ fun processServiceProvider(
     val errorList = mutableListOf<String>()
     serviceInfoList.forEach {
         errorList.addAll(checkFunctionSupportType(it.functionList))
+        errorList.addAll(checkAsyncServiceSupportType(it.functionList))
     }
     serviceInfoList.forEach {
         if (!it.declaration.modifiers.contains(Modifier.OPEN) || it.declaration.modifiers.contains(
@@ -128,9 +131,31 @@ fun genServiceProviderClass(serviceInfo: ServiceInfo): TypeSpec {
         .superclass(serviceInfo.clazzName.toTypeName()).addSuperinterface(Invokable::class)
     serviceProviderTypeSpec.addFunction(genGetReturnTypeFuncSpec(serviceInfo))
     serviceProviderTypeSpec.addFunction(genGetParamTypeListFuncSpec(serviceInfo))
+    serviceProviderTypeSpec.addFunction(genIsRetPromiseFunSpec(serviceInfo))
     serviceProviderTypeSpec.addFunction(genInvokeFuncSpec(serviceInfo))
     serviceProviderTypeSpec.addFunction(genMinParamsSizeFunSpec(serviceInfo))
     return serviceProviderTypeSpec.build()
+}
+
+fun genIsRetPromiseFunSpec(serviceInfo: ServiceInfo): FunSpec {
+    val func = FunSpec.builder("isRetPromise").addModifiers(KModifier.OVERRIDE)
+    func.addParameter("method", String::class)
+    var totalCode = ""
+    serviceInfo.functionList.forEach {
+        totalCode += "|    \"${it.functionName}\" -> ${it.retPromise}\n"
+    }
+    func.addCode(
+        """
+        |return when (method) {
+            $totalCode
+        |    else -> {
+        |        throw IllegalArgumentException("${serviceInfo.serviceName}#${'$'}method not found.")
+        |    }
+        |}
+        |""".trimMargin()
+    )
+    func.returns(BOOLEAN)
+    return func.build()
 }
 
 fun genMinParamsSizeFunSpec(serviceInfo: ServiceInfo): FunSpec {

--- a/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/tsgen/TypeScriptInterfaceGenerator.kt
+++ b/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/tsgen/TypeScriptInterfaceGenerator.kt
@@ -45,12 +45,20 @@ fun genTypeScriptInterface(name: String, functionList: List<FunctionInfo>): Stri
         }
         paramsStr
     }
+    val genReturnFun = { function: FunctionInfo ->
+        val jsType = getJSTypeByKsType(function.returnType)
+        if (function.retPromise) {
+            "Promise<$jsType>"
+        } else {
+            jsType
+        }
+    }
     return """
         |export interface $name {
             ${
         functionList.joinToString(separator = "") {
             """
-            |   ${it.functionName}(${genParamsFun(it)}): ${getJSTypeByKsType(it.returnType)};
+            |   ${it.functionName}(${genParamsFun(it)}): ${genReturnFun(it)};
             |"""
         }
     }

--- a/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/utils/Utils.kt
+++ b/knoi/knoi-processor/src/main/kotlin/com/tencent/tmm/knoi/utils/Utils.kt
@@ -109,6 +109,23 @@ fun checkAsyncFunctionSupportType(functionList: List<AsyncExportFunction>): Muta
     return result
 }
 
+fun checkAsyncServiceSupportType(functionList: List<FunctionInfo>): MutableList<String> {
+    val result = mutableListOf<String>()
+    functionList.filter { it.retPromise }.forEach { function ->
+        function.returnType?.let { returnType ->
+            validateAsyncExportTypeShape(returnType.toAsyncTypeShape())?.let { message ->
+                result.add("${function.packageName}#${function.functionName}\n $message")
+            }
+        }
+        function.parameters.forEach { param ->
+            validateAsyncExportTypeShape(param.type.toAsyncTypeShape())?.let { message ->
+                result.add("${function.packageName}#${function.functionName}\n $message")
+            }
+        }
+    }
+    return result
+}
+
 fun <T> getAnnotationValueByKey(
     annotation: KSAnnotated, annotationName: String, key: String, fallback: T
 ): T {

--- a/knoi/knoi/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/definder/AsyncFunctionDefinder.kt
+++ b/knoi/knoi/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/definder/AsyncFunctionDefinder.kt
@@ -126,7 +126,7 @@ private fun buildAsyncFunctionParams(
     }
 }
 
-private fun jsValueToAsyncKTValue(
+internal fun jsValueToAsyncKTValue(
     env: napi_env?,
     value: napi_value?,
     kType: KClass<out Any>
@@ -142,7 +142,7 @@ private fun jsValueToAsyncKTValue(
     return normalizeAsyncInputValue(converted)
 }
 
-private fun ktValueToAsyncJSValue(
+internal fun ktValueToAsyncJSValue(
     env: napi_env?,
     value: Any?,
     clazz: KClass<out Any>,
@@ -165,7 +165,7 @@ private fun ktValueToAsyncJSValue(
     }
 }
 
-private fun normalizeAsyncInputValue(value: Any?): Any? {
+internal fun normalizeAsyncInputValue(value: Any?): Any? {
     return when (value) {
         null -> null
         is List<*> -> value.map { normalizeAsyncInputValue(it) }
@@ -175,7 +175,7 @@ private fun normalizeAsyncInputValue(value: Any?): Any? {
     }
 }
 
-private fun normalizeAsyncOutputValue(value: Any?, ownerTid: Int): Any? {
+internal fun normalizeAsyncOutputValue(value: Any?, ownerTid: Int): Any? {
     return when (value) {
         null -> null
         is JSValue -> {
@@ -218,7 +218,7 @@ internal fun forwardInvokeRetPromise(env: napi_env?, callbackInfo: napi_callback
     }
 }
 
-private fun createAsyncThrowableValue(env: napi_env?, throwable: Throwable?): napi_value? {
+internal fun createAsyncThrowableValue(env: napi_env?, throwable: Throwable?): napi_value? {
     val message = throwable?.message ?: throwable?.toString() ?: "Unknown async error"
     return createError(env, message)
 }

--- a/knoi/knoi/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/definder/ServiceDefinder.kt
+++ b/knoi/knoi/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/definder/ServiceDefinder.kt
@@ -5,6 +5,7 @@ import com.tencent.tmm.knoi.converter.jsValueToKTValue
 import com.tencent.tmm.knoi.converter.ktValueToJSValue
 import com.tencent.tmm.knoi.getEnv
 import com.tencent.tmm.knoi.injectEnv
+import com.tencent.tmm.knoi.setCurrentAsyncInvokeOwnerTid
 import com.tencent.tmm.knoi.logger.debug
 import com.tencent.tmm.knoi.logger.info
 import com.tencent.tmm.knoi.metric.trace
@@ -16,20 +17,57 @@ import com.tencent.tmm.knoi.register.ServiceProxyRegister
 import com.tencent.tmm.knoi.register.getInvokable
 import com.tencent.tmm.knoi.service.Invokable
 import com.tencent.tmm.knoi.type.JSValue
+import kotlinx.cinterop.COpaquePointer
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.StableRef
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.asStableRef
 import kotlinx.cinterop.get
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
 import kotlinx.cinterop.staticCFunction
+import kotlinx.cinterop.value
+import platform.ohos.knoi.createAsyncWork
+import platform.ohos.knoi.createPromise
+import platform.ohos.knoi.deleteAsyncWork
+import platform.ohos.knoi.getAndClearLastException
 import platform.ohos.knoi.getCbInfoWithSize
+import platform.ohos.knoi.getCallbackInfoParamsSize
+import platform.ohos.knoi.getUndefined
+import platform.ohos.knoi.get_tid
+import platform.ohos.knoi.queueAsyncWork
+import platform.ohos.knoi.rejectDeferred
+import platform.ohos.knoi.resolveDeferred
 import platform.ohos.knoi.typeOf
+import platform.ohos.napi_async_work
 import platform.ohos.napi_callback_info
+import platform.ohos.napi_deferred
 import platform.ohos.napi_env
+import platform.ohos.napi_pending_exception
+import platform.ohos.napi_status
 import platform.ohos.napi_value
+import platform.ohos.napi_valueVar
 import platform.ohos.napi_valuetype
+import platform.posix.free
 import kotlin.reflect.KClass
 
 const val JS_REGISTER_SERVICE_METHOD_NAME = "registerServiceProvider"
 const val JS_CALL_SERVICE_METHOD_NAME = "callService"
 
 val serviceProxyRegister = ServiceProxyRegister()
+
+private class PromiseAsyncServiceExecutionContext(
+    val invokable: Invokable,
+    val methodName: String,
+    val params: Array<out Any?>,
+    val ownerTid: Int,
+    val returnType: KClass<out Any>,
+    val deferred: napi_deferred?
+) {
+    var work: napi_async_work? = null
+    var result: Any? = null
+    var throwable: Throwable? = null
+}
 
 /**
  * 注册服务调用相关 API 至 export 对象
@@ -107,6 +145,10 @@ internal fun forwardServiceCall(env: napi_env?, callbackInfo: napi_callback_info
     val paramsTypes = invokable.getParamsTypeList(methodName)
     val expectedSize = invokable.getMinParamsSize(methodName)
 
+    if (invokable.isRetPromise(methodName)) {
+        return forwardPromiseServiceCall(env, callbackInfo, serviceName, methodName, invokable, paramsTypes, expectedSize)
+    }
+
     val paramsValue =
         convertJSCallbackInfoToKTParamList<Any>(env, callbackInfo, paramsTypes.toList(), 3)
     if (paramsValue.size < expectedSize) {
@@ -122,6 +164,123 @@ internal fun forwardServiceCall(env: napi_env?, callbackInfo: napi_callback_info
         val result = invokable.invoke(methodName, *transformParamValues)
         debug("callService $serviceName#$methodName : result = $result")
         ktValueToJSValue(env, result, invokable.getReturnType(methodName))
+    }
+}
+
+private fun buildAsyncServiceParams(
+    env: napi_env?,
+    callbackInfo: napi_callback_info?,
+    methodName: String,
+    paramsTypes: Array<out KClass<out Any>>,
+    offset: Int = 3
+): Array<out Any?> {
+    val jsParamsSize = getCallbackInfoParamsSize(env, callbackInfo)
+    val maxExpectedSize = paramsTypes.size + offset
+    if (jsParamsSize > maxExpectedSize) {
+        throw IllegalArgumentException(
+            "callService method = $methodName params length error: expect at most ${paramsTypes.size} actual ${jsParamsSize - offset}"
+        )
+    }
+    val params = getCbInfoWithSize(env, callbackInfo, jsParamsSize) ?: error("unknown params.")
+    return try {
+        val paramsValue = mutableListOf<Any?>()
+        for (index in offset until jsParamsSize) {
+            val type = paramsTypes[index - offset]
+            val value = jsValueToAsyncKTValue(env, params[index], type)
+            paramsValue.add(safeCaseNumberType(value, type))
+        }
+        paramsValue.toTypedArray()
+    } finally {
+        free(params)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun forwardPromiseServiceCall(
+    env: napi_env?,
+    callbackInfo: napi_callback_info?,
+    serviceName: String,
+    methodName: String,
+    invokable: Invokable,
+    paramsTypes: Array<out KClass<out Any>>,
+    expectedSize: Int
+): napi_value? {
+    val paramsValue = buildAsyncServiceParams(env, callbackInfo, methodName, paramsTypes)
+    if (paramsValue.size < expectedSize) {
+        throw IllegalArgumentException(
+            "callService method = $methodName params length error: expect $expectedSize actual ${paramsValue.size}"
+        )
+    }
+    val ownerTid = get_tid()
+    val returnType = invokable.getReturnType(methodName)
+    return trace("forwardPromiseServiceCall $serviceName#$methodName") {
+        debug("callService promise $serviceName#$methodName : params = ${paramsValue.contentToString()}")
+        memScoped {
+            val promiseValue = alloc<napi_valueVar>()
+            val deferred = createPromise(env, promiseValue.ptr)
+            val context = PromiseAsyncServiceExecutionContext(
+                invokable = invokable,
+                methodName = methodName,
+                params = paramsValue,
+                ownerTid = ownerTid,
+                returnType = returnType,
+                deferred = deferred
+            )
+            val ref = StableRef.create(context)
+            val work = createAsyncWork(
+                env,
+                "KnoiCallServicePromise",
+                staticCFunction(::executePromiseServiceCall),
+                staticCFunction(::completePromiseServiceCall),
+                ref.asCPointer()
+            )
+            context.work = work
+            queueAsyncWork(env, work)
+            return@memScoped promiseValue.value
+        }
+    }
+}
+
+internal fun executePromiseServiceCall(env: napi_env?, data: COpaquePointer?) {
+    val context = data?.asStableRef<PromiseAsyncServiceExecutionContext>()?.get() ?: return
+    try {
+        setCurrentAsyncInvokeOwnerTid(context.ownerTid)
+        context.result = context.invokable.invoke(context.methodName, *context.params)
+    } catch (t: Throwable) {
+        context.throwable = t
+    } finally {
+        setCurrentAsyncInvokeOwnerTid(null)
+    }
+}
+
+internal fun completePromiseServiceCall(
+    env: napi_env?,
+    status: napi_status,
+    data: COpaquePointer?
+) {
+    val ref = data?.asStableRef<PromiseAsyncServiceExecutionContext>() ?: return
+    val context = ref.get()
+    try {
+        injectEnv(env)
+        if (status == napi_pending_exception) {
+            rejectDeferred(env, context.deferred, getAndClearLastException(env))
+            return
+        }
+        val throwable = context.throwable
+        if (throwable != null) {
+            rejectDeferred(env, context.deferred, createAsyncThrowableValue(env, throwable))
+            return
+        }
+        val value = try {
+            ktValueToAsyncJSValue(env, context.result, context.returnType, context.ownerTid)
+        } catch (t: Throwable) {
+            rejectDeferred(env, context.deferred, createAsyncThrowableValue(env, t))
+            return
+        }
+        resolveDeferred(env, context.deferred, value ?: getUndefined(env))
+    } finally {
+        deleteAsyncWork(env, context.work)
+        ref.dispose()
     }
 }
 

--- a/knoi/knoi/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/definder/ServiceDefinder.kt
+++ b/knoi/knoi/src/ohosArm64Main/kotlin/com/tencent/tmm/knoi/definder/ServiceDefinder.kt
@@ -126,44 +126,56 @@ fun <T> bindServiceProxy(name: String, proxy: T) {
 internal fun forwardServiceCall(env: napi_env?, callbackInfo: napi_callback_info?): napi_value? {
     injectEnv(env)
     val params = getCbInfoWithSize(env, callbackInfo, 3) ?: error("unknown params.")
-    if (params[0] == null || params[1] == null || params[2] == null) {
-        return null
-    }
-    val serviceNameJSValue = JSValue(params[0])
-    if (!serviceNameJSValue.isString() || serviceNameJSValue.toKString().isNullOrEmpty()) {
-        throw IllegalArgumentException("The first parameter must be the service name.")
-    }
+    try {
+        if (params[0] == null || params[1] == null || params[2] == null) {
+            return null
+        }
+        val serviceNameJSValue = JSValue(params[0])
+        if (!serviceNameJSValue.isString() || serviceNameJSValue.toKString().isNullOrEmpty()) {
+            throw IllegalArgumentException("The first parameter must be the service name.")
+        }
 
-    val proxyJSValue = JSValue(params[1])
-    val methodName = jsValueToKTValue(getEnv(), params[2], String::class)
-    if (methodName !is String) {
-        throw IllegalArgumentException("The third parameter must be the method name.")
-    }
+        val proxyJSValue = JSValue(params[1])
+        val methodName = jsValueToKTValue(getEnv(), params[2], String::class)
+        if (methodName !is String) {
+            throw IllegalArgumentException("The third parameter must be the method name.")
+        }
 
-    val serviceName = serviceNameJSValue.toKString()!!
-    val invokable = serviceProviderRegister.getInvokable(proxyJSValue, serviceName)
-    val paramsTypes = invokable.getParamsTypeList(methodName)
-    val expectedSize = invokable.getMinParamsSize(methodName)
+        val serviceName = serviceNameJSValue.toKString()!!
+        val invokable = serviceProviderRegister.getInvokable(proxyJSValue, serviceName)
+        val paramsTypes = invokable.getParamsTypeList(methodName)
+        val expectedSize = invokable.getMinParamsSize(methodName)
 
-    if (invokable.isRetPromise(methodName)) {
-        return forwardPromiseServiceCall(env, callbackInfo, serviceName, methodName, invokable, paramsTypes, expectedSize)
-    }
+        if (invokable.isRetPromise(methodName)) {
+            return forwardPromiseServiceCall(
+                env,
+                callbackInfo,
+                serviceName,
+                methodName,
+                invokable,
+                paramsTypes,
+                expectedSize
+            )
+        }
 
-    val paramsValue =
-        convertJSCallbackInfoToKTParamList<Any>(env, callbackInfo, paramsTypes.toList(), 3)
-    if (paramsValue.size < expectedSize) {
-        throw IllegalArgumentException(
-            "callService method = $methodName " + "params length error: expect $expectedSize actual ${paramsValue.size}"
-        )
-    }
-    val transformParamValues = paramsValue.mapIndexed { index: Int, param: Any? ->
-        return@mapIndexed safeCaseNumberType(param, paramsTypes[index])
-    }.toTypedArray()
-    return trace("forwardServiceCall $serviceName#$methodName") {
-        debug("callService $serviceName#$methodName : params = ${transformParamValues.contentToString()}")
-        val result = invokable.invoke(methodName, *transformParamValues)
-        debug("callService $serviceName#$methodName : result = $result")
-        ktValueToJSValue(env, result, invokable.getReturnType(methodName))
+        val paramsValue =
+            convertJSCallbackInfoToKTParamList<Any>(env, callbackInfo, paramsTypes.toList(), 3)
+        if (paramsValue.size < expectedSize) {
+            throw IllegalArgumentException(
+                "callService method = $methodName " + "params length error: expect $expectedSize actual ${paramsValue.size}"
+            )
+        }
+        val transformParamValues = paramsValue.mapIndexed { index: Int, param: Any? ->
+            return@mapIndexed safeCaseNumberType(param, paramsTypes[index])
+        }.toTypedArray()
+        return trace("forwardServiceCall $serviceName#$methodName") {
+            debug("callService $serviceName#$methodName : params = ${transformParamValues.contentToString()}")
+            val result = invokable.invoke(methodName, *transformParamValues)
+            debug("callService $serviceName#$methodName : result = $result")
+            ktValueToJSValue(env, result, invokable.getReturnType(methodName))
+        }
+    } finally {
+        free(params)
     }
 }
 
@@ -290,25 +302,29 @@ internal fun completePromiseServiceCall(
 internal fun registerService(env: napi_env?, callbackInfo: napi_callback_info?): napi_value? {
     injectEnv(env)
     val params = getCbInfoWithSize(env, callbackInfo, 3) ?: error("unknown params.")
-    if (params[0] == null || params[1] == null || params[2] == null) {
-        return null
-    }
-    val nameJSValue = JSValue(params[0])
-    if (!nameJSValue.isString() || nameJSValue.toKString().isNullOrEmpty()) {
-        throw IllegalArgumentException("The first parameter must be the service name.")
-    }
-    val serviceName = nameJSValue.toKString()!!
+    try {
+        if (params[0] == null || params[1] == null || params[2] == null) {
+            return null
+        }
+        val nameJSValue = JSValue(params[0])
+        if (!nameJSValue.isString() || nameJSValue.toKString().isNullOrEmpty()) {
+            throw IllegalArgumentException("The first parameter must be the service name.")
+        }
+        val serviceName = nameJSValue.toKString()!!
 
-    val singletonJSValue = JSValue(params[1])
-    if (!singletonJSValue.isBoolean()) {
-        throw IllegalArgumentException("The second parameter must be Boolean.")
+        val singletonJSValue = JSValue(params[1])
+        if (!singletonJSValue.isBoolean()) {
+            throw IllegalArgumentException("The second parameter must be Boolean.")
+        }
+        val type = typeOf(env, params[2])
+        if (type != napi_valuetype.napi_object && type != napi_valuetype.napi_function) {
+            throw IllegalArgumentException("serviceName $serviceName The third parameter must be a function or object.")
+        }
+        val isSingleton = singletonJSValue.toBoolean()
+        info("registerService service = $serviceName  isSingleton = $isSingleton")
+        serviceProxyRegister.register(env, serviceName, isSingleton, params[2])
+        return null
+    } finally {
+        free(params)
     }
-    val type = typeOf(env, params[2])
-    if (type != napi_valuetype.napi_object && type != napi_valuetype.napi_function) {
-        throw IllegalArgumentException("serviceName $serviceName The third parameter must be a function or object.")
-    }
-    val isSingleton = singletonJSValue.toBoolean()
-    info("registerService service = $serviceName  isSingleton = $isSingleton")
-    serviceProxyRegister.register(env, serviceName, isSingleton, params[2])
-    return null
 }

--- a/knoi/ohosApp/entry/src/main/ets/knoi/provider.ets
+++ b/knoi/ohosApp/entry/src/main/ets/knoi/provider.ets
@@ -105,13 +105,23 @@ export interface TestServiceB {
 
    methodWithUnit(): void;
 
+   methodWithPromiseString(a: string): Promise<string>;
+
+   methodWithPromiseJSValueReturnJSValue(a: object): Promise<object>;
+
+   methodWithPromiseUnitReturnJSValue(): Promise<object>;
+
    methodWithJSValueReturnJSValue(a: object): object;
 
    methodWithArrayBufferReturnArrayBuffer(buffer: ArrayBuffer): ArrayBuffer;
 
+   methodWithPromiseArrayBufferReturnArrayBuffer(buffer: ArrayBuffer): Promise<ArrayBuffer>;
+
    method3Params(a: string, b: number, c: object): object;
 
    methodWithMultiTypeMap(map: object): object;
+
+   methodWithPromiseMapReturnMap(map: object): Promise<object>;
 
    methodWithDefaultValueInSubType(a?: number, b?: string): void;
 

--- a/knoi/ohosApp/entry/src/main/ets/pages/Index.ets
+++ b/knoi/ohosApp/entry/src/main/ets/pages/Index.ets
@@ -17,6 +17,12 @@ import router from '@ohos.router';
 import { display } from '@kit.ArkUI'
 import TestServiceAInWorkerImpl from '../TestServiceAInWorkerImpl'
 
+interface PromiseServiceObjectPayload {
+  name: string
+  count: number
+  enabled: boolean
+}
+
 @Entry
 @Component
 struct Index {
@@ -417,6 +423,32 @@ struct Index {
             console.log("knoi-sample TestServiceB methodWithIntReturnInt result = " + intResult)
             let strResult = serviceB.methodWithStringReturnString("param in ArkTS")
             console.log("knoi-sample TestServiceB methodWithStringReturnString result = " + strResult)
+            serviceB.methodWithPromiseString("promise param in ArkTS")
+              .then((promiseResult: string) => {
+                console.log("knoi-sample TestServiceB methodWithPromiseString result = " + promiseResult)
+              })
+              .catch((error: Error) => {
+                console.error("knoi-sample TestServiceB methodWithPromiseString error = " + error.message)
+              })
+            let promiseJSValueInput: PromiseServiceObjectPayload = {
+              name: "arkts",
+              count: 1,
+              enabled: true
+            }
+            serviceB.methodWithPromiseJSValueReturnJSValue(promiseJSValueInput)
+              .then((promiseResult: Object) => {
+                console.log("knoi-sample TestServiceB methodWithPromiseJSValueReturnJSValue result = " + JSON.stringify(promiseResult))
+              })
+              .catch((error: Error) => {
+                console.error("knoi-sample TestServiceB methodWithPromiseJSValueReturnJSValue error = " + error.message)
+              })
+            serviceB.methodWithPromiseUnitReturnJSValue()
+              .then((promiseResult: Object) => {
+                console.log("knoi-sample TestServiceB methodWithPromiseUnitReturnJSValue result = " + JSON.stringify(promiseResult))
+              })
+              .catch((error: Error) => {
+                console.error("knoi-sample TestServiceB methodWithPromiseUnitReturnJSValue error = " + error.message)
+              })
             let longResult = serviceB.methodWithLongReturnLong(42)
             console.log("knoi-sample TestServiceB methodWithLongReturnLong result = " + longResult)
             let doubleResult = serviceB.methodWithDoubleReturnDouble(42.0)
@@ -435,6 +467,32 @@ struct Index {
             console.log("knoi-sample TestServiceB methodWithMapReturnMap result = " + objResult)
             serviceB.methodWithUnit()
             console.log("knoi-sample TestServiceB methodWithUnit result")
+            let promiseBuffer: ArrayBuffer = new ArrayBuffer(8)
+            let promiseBufferArray: Uint8Array = new Uint8Array(promiseBuffer)
+            promiseBufferArray[0] = 1
+            promiseBufferArray[1] = 2
+            promiseBufferArray[2] = 3
+            promiseBufferArray[3] = 4
+            serviceB.methodWithPromiseArrayBufferReturnArrayBuffer(promiseBuffer)
+              .then((promiseResult: ArrayBuffer) => {
+                let bytes = Array.from(new Uint8Array(promiseResult)).join(",")
+                console.log("knoi-sample TestServiceB methodWithPromiseArrayBufferReturnArrayBuffer result = " + bytes)
+              })
+              .catch((error: Error) => {
+                console.error("knoi-sample TestServiceB methodWithPromiseArrayBufferReturnArrayBuffer error = " + error.message)
+              })
+            let promiseMapInput: PromiseServiceObjectPayload = {
+              name: "promise-map",
+              count: 2,
+              enabled: false
+            }
+            serviceB.methodWithPromiseMapReturnMap(promiseMapInput)
+              .then((promiseResult: Object) => {
+                console.log("knoi-sample TestServiceB methodWithPromiseMapReturnMap result = " + JSON.stringify(promiseResult))
+              })
+              .catch((error: Error) => {
+                console.error("knoi-sample TestServiceB methodWithPromiseMapReturnMap error = " + error.message)
+              })
             let func: Function = serviceB.methodWithCallbackReturnCallback((a: string) => {
               console.log("knoi-sample TestServiceB methodWithCallbackReturnCallback result = " + a)
             })


### PR DESCRIPTION
- Added support for methods in classes annotated with `@ServiceProvider` for `@KNMethodRetPromise`.
- Added support for methods that are overridden to check if `@KNMethodRetPromise` is used in their parent class, meaning `@KNMethodRetPromise` supports inheritance.
- Fixed an issue where `forwardServiceCall()` and `registerService()` did not release memory.
- Added example cases related to `@KNMethodRetPromise`.