### PR TITLE
Support custom HTTP methods in NetworkKMM

### DIFF
--- a/NetworkKMM/README-zh.md
+++ b/NetworkKMM/README-zh.md
@@ -116,7 +116,26 @@ VBTransportService.sendRequest(request) { response ->
 }
 ```
 
-如果服务端要求 multipart/form-data，可以自行拼接 multipart body bytes，并设置带 boundary 的 `Content-Type` 后再赋值给 `data`.
+#### Multipart 文件上传
+```kotlin
+val multipartBody = VBTransportMultipartBodyBuilder()
+    .addFormField("name", "Kuikly")
+    .addFormField("uploadType", "multipart")
+    .addFile("file", "sample.bin", fileBytes, VBTransportContentType.BYTE.toString())
+    .build()
+
+val request = VBTransportRequest().apply {
+    method = VBTransportMethod.POST
+    url = "https://httpbin.org/post"
+    header["Authorization"] = "Bearer sample-token"
+    setMultipartBody(multipartBody)
+    totalTimeout = 10000
+}
+
+VBTransportService.sendRequest(request) { response ->
+    println(response.data)
+}
+```
 
 ### demo 工程运行使用说明
 #### Android

--- a/NetworkKMM/README-zh.md
+++ b/NetworkKMM/README-zh.md
@@ -13,10 +13,15 @@
 
 #### Kotlin 接入
 ```kotlin
+repositories {
+    maven {
+        url = uri("https://mirrors.tencent.com/nexus/repository/maven-tencent/")
+    }
+}
 
-  // 在build.gradle.kts 添加依赖
-  implementation("com.tencent.kuiklybase:network:0.0.3")
-  // 如有疑问，参考各端demo app接入 (androidApp/, iosApp/, ohosApp/目录下的示例)
+// 在 build.gradle.kts / build.ohos.gradle.kts 添加依赖
+implementation("com.tencent.kuiklybase:network:0.0.4")
+// 如有疑问，参考各端 demo app 接入 (androidApp/, iosApp/, ohosApp/目录下的示例)
 ```
 
 #### 网络权限声明
@@ -26,41 +31,61 @@
 <uses-permission android:name="android.permission.INTERNET" />
 ```
 ##### HarmonyOS
-```kotlin
-// 工程的module.json5中添加
+```json5
+// 工程的 entry/src/main/module.json5 中添加
 "requestPermissions": [
       {
         "name": "ohos.permission.INTERNET",
-        "reason": "$string:reason",
+        "reason": "$string:internet_permission_reason",
         "usedScene": {
           "abilities": [
-            "FormAbility"
+            "EntryAbility"
           ],
           "when": "inuse"
         }
       },
       {
         "name": "ohos.permission.GET_NETWORK_INFO",
-        "reason": "$string:reason",
+        "reason": "$string:network_info_permission_reason",
         "usedScene": {
           "abilities": [
-            "FormAbility"
+            "EntryAbility"
           ],
           "when": "inuse"
         }
       },
       {
         "name": "ohos.permission.GET_WIFI_INFO",
-        "reason": "$string:reason",
+        "reason": "$string:wifi_info_permission_reason",
         "usedScene": {
           "abilities": [
-            "FormAbility"
+            "EntryAbility"
           ],
           "when": "inuse"
         }
       }
 ]
 ```
+
+#### HarmonyOS Native 库接入
+鸿蒙端底层通过 `pbcurlwrapper` 调用 libcurl，除了 Kotlin 依赖和权限，还必须集成 native 库。详细步骤见 [HarmonyOS 接入文档](./docs/harmonyos-integration.md)。
+
+必须下载并放置以下两个 `.so` 文件：
+
+| 库文件 | 作用 | 下载链接 |
+| --- | --- | --- |
+| `libpbcurlwrapper.so` | curl 网络请求封装库 | [下载](https://drive.weixin.qq.com/s?k=AJEAIQdfAAoOl8vBYTAbQAJgZ2AA8) |
+| `libopenssl.so` | HTTPS/SSL 支持库 | [下载](https://drive.weixin.qq.com/s?k=AJEAIQdfAAohnXGmhhAbQAJgZ2AA8) |
+
+放置路径：
+
+```text
+ohosApp/entry/libs/arm64-v8a/
+├── libpbcurlwrapper.so
+└── libopenssl.so
+```
+
+如果业务鸿蒙工程存在 native entry CMake target，还需要在 `ohosApp/entry/src/main/cpp/CMakeLists.txt` 中 `add_library(... IMPORTED)` 并在 `target_link_libraries` 中链接 `pbcurlwrapper openssl`。当前 demo 工程已在 `NetworkKMM/ohosApp/entry/libs/arm64-v8a/` 内置上述库文件；外部项目接入时需要自行拷贝或下载。
 
 #### 初始化
 ```kotlin
@@ -154,14 +179,16 @@ pod 'network', :path => '../network/build/cocoapods/publish/debug'
 ```kotlin
 1) 编译 libkn.so 产物, Gradle 任务路径在: NetworkKMM/network-sample/build/ohosArm64Binaries
 2) 编译产生的 libkn.so 产物在 network-sample 的临时 build/bin/ohosArm64_debugShared/libkn.so 文件里可以找到
-3) 将该 libkn.so 拷贝到 ohosApp/entry/libs/ 目录下, 覆盖已有的 libkn.so 文件.
-4) 鸿蒙 IDE(DevEco-Studio) 打开 ohosApp工程运行即可.
+3) 将该 libkn.so 拷贝到 ohosApp/entry/libs/arm64-v8a/ 目录下, 覆盖已有的 libkn.so 文件.
+4) 确认 ohosApp/entry/libs/arm64-v8a/ 中存在 libkn.so、libpbcurlwrapper.so、libopenssl.so
+5) 鸿蒙 IDE(DevEco-Studio) 打开 ohosApp 工程运行即可.
 ```
 
 ### 说明
 1. 鸿蒙端目前底层网络请求使用开源库libcurl, 但没有直接调用libcurl的接口,而是在其基础上封装了一层wrapper层,供kotlin端调用.封装代码在: ohosApp/pbcurlwrapper/下.
 2. 若需修改封装层的逻辑,修改完打产物时,直接在 DevEco-Studio 里,针对 pbcurlwrapper 执行 Build/Make Module 'pbcurlwrapper' 即可, 其产物在 pbcurlwrapper 目录下的临时文件夹 build/default/intermediate/cmake/default/obj/arm64-v8a/libpbcurlwrapper.so 中找到.
-3. 若修改完想在 ohosApp 这个demo工程里运行,可以将build下的这个so手动拷贝到entry/libs/arm64-v8a/下,覆盖原有的so文件即可.
+3. 若修改完想在 ohosApp 这个 demo 工程里运行,可以将 build 下的 libpbcurlwrapper.so 手动拷贝到 entry/libs/arm64-v8a/ 下,覆盖原有的 so 文件即可.
+4. 外部 HarmonyOS 工程接入时,请按 [HarmonyOS 接入文档](./docs/harmonyos-integration.md) 同时配置权限、native 库和 CMake 链接.
 
 ### ChangeLog
 

--- a/NetworkKMM/README-zh.md
+++ b/NetworkKMM/README-zh.md
@@ -83,7 +83,7 @@ VBTransportInitHelper.init(config)
 ```
 
 ### 常用网络请求示例
-在 network/src/commonMain/service/VBTransportServiceTest.kt 中包含一些常用http get/post/string/byte 类型请求示例,可以参考.
+在 network/src/commonMain/service/VBTransportServiceTest.kt 中包含一些常用 http get/post/string/byte/自定义 method 类型请求示例,可以参考.
 
 ### demo 工程运行使用说明
 #### Android

--- a/NetworkKMM/README-zh.md
+++ b/NetworkKMM/README-zh.md
@@ -85,6 +85,39 @@ VBTransportInitHelper.init(config)
 ### 常用网络请求示例
 在 network/src/commonMain/service/VBTransportServiceTest.kt 中包含一些常用 http get/post/string/byte/自定义 method 类型请求示例,可以参考.
 
+#### 自定义 Method 请求
+```kotlin
+val request = VBTransportRequest().apply {
+    method = VBTransportMethod.PUT
+    url = "https://httpbin.org/put"
+    header["Content-Type"] = VBTransportContentType.JSON.toString()
+    header["Authorization"] = "Bearer sample-token"
+    data = """{"name":"Kuikly","method":"PUT"}"""
+}
+
+VBTransportService.sendRequest(request) { response ->
+    println(response.data)
+}
+```
+
+#### 二进制文件上传
+```kotlin
+val request = VBTransportRequest().apply {
+    method = VBTransportMethod.POST
+    url = "https://httpbin.org/post"
+    header["Content-Type"] = VBTransportContentType.BYTE.toString()
+    header["X-File-Name"] = "sample.bin"
+    data = fileBytes
+    totalTimeout = 10000
+}
+
+VBTransportService.sendRequest(request) { response ->
+    println(response.errorMessage)
+}
+```
+
+如果服务端要求 multipart/form-data，可以自行拼接 multipart body bytes，并设置带 boundary 的 `Content-Type` 后再赋值给 `data`.
+
 ### demo 工程运行使用说明
 #### Android
 直接 run androidApp target 即可.

--- a/NetworkKMM/README.md
+++ b/NetworkKMM/README.md
@@ -13,8 +13,14 @@ Currently, the HarmonyOS side uses the open-source library **libcurl** as the ne
 
 #### Kotlin Integration
 ```kotlin
-// Add the dependency in build.gradle.kts
-implementation("com.tencent.kuiklybase:network:0.0.3")
+repositories {
+    maven {
+        url = uri("https://mirrors.tencent.com/nexus/repository/maven-tencent/")
+    }
+}
+
+// Add the dependency in build.gradle.kts / build.ohos.gradle.kts
+implementation("com.tencent.kuiklybase:network:0.0.4")
 // For more details, refer to the demo apps for each platform (see androidApp/, iosApp/, ohosApp/ directories)
 ```
 
@@ -25,41 +31,61 @@ implementation("com.tencent.kuiklybase:network:0.0.3")
 <uses-permission android:name="android.permission.INTERNET" />
 ```
 ##### HarmonyOS
-```kotlin
+```json5
 // Add in the module.json5 file of your project
 "requestPermissions": [
       {
         "name": "ohos.permission.INTERNET",
-        "reason": "$string:reason",
+        "reason": "$string:internet_permission_reason",
         "usedScene": {
           "abilities": [
-            "FormAbility"
+            "EntryAbility"
           ],
           "when": "inuse"
         }
       },
       {
         "name": "ohos.permission.GET_NETWORK_INFO",
-        "reason": "$string:reason",
+        "reason": "$string:network_info_permission_reason",
         "usedScene": {
           "abilities": [
-            "FormAbility"
+            "EntryAbility"
           ],
           "when": "inuse"
         }
       },
       {
         "name": "ohos.permission.GET_WIFI_INFO",
-        "reason": "$string:reason",
+        "reason": "$string:wifi_info_permission_reason",
         "usedScene": {
           "abilities": [
-            "FormAbility"
+            "EntryAbility"
           ],
           "when": "inuse"
         }
       }
 ]
 ```
+
+#### HarmonyOS Native Libraries
+HarmonyOS uses libcurl through `pbcurlwrapper`, so app projects must integrate native libraries in addition to the Kotlin dependency and permissions. See [HarmonyOS Integration](./docs/harmonyos-integration.md) for the complete steps.
+
+Required libraries:
+
+| Library | Purpose | Download |
+| --- | --- | --- |
+| `libpbcurlwrapper.so` | curl request wrapper | [download](https://drive.weixin.qq.com/s?k=AJEAIQdfAAoOl8vBYTAbQAJgZ2AA8) |
+| `libopenssl.so` | HTTPS/SSL support | [download](https://drive.weixin.qq.com/s?k=AJEAIQdfAAohnXGmhhAbQAJgZ2AA8) |
+
+Place them here:
+
+```text
+ohosApp/entry/libs/arm64-v8a/
+├── libpbcurlwrapper.so
+└── libopenssl.so
+```
+
+If the app has a native entry CMake target, import both libraries with `add_library(... IMPORTED)` in `ohosApp/entry/src/main/cpp/CMakeLists.txt` and add `pbcurlwrapper openssl` to `target_link_libraries`. The sample project already includes these libraries under `NetworkKMM/ohosApp/entry/libs/arm64-v8a/`; external app projects must copy or download them into their own entry module.
 
 #### Initialization
 ```kotlin
@@ -153,14 +179,16 @@ Simply run the androidApp target.
 ```kotlin
 1) Build the libkn.so artifact. The Gradle task path is: NetworkKMM/network-sample/build/ohosArm64Binaries
 2) The generated libkn.so artifact can be found in the temporary build/bin/ohosArm64_debugShared/libkn.so folder of network-sample
-3) Copy the libkn.so file to the ohosApp/entry/libs/ directory, overwriting the existing libkn.so file
-4) Open the ohosApp project in DevEco-Studio and run it
+3) Copy libkn.so to ohosApp/entry/libs/arm64-v8a/, overwriting the existing libkn.so file
+4) Confirm ohosApp/entry/libs/arm64-v8a/ contains libkn.so, libpbcurlwrapper.so, and libopenssl.so
+5) Open the ohosApp project in DevEco-Studio and run it
 ```
 
 ### Notes
 1. The HarmonyOS side currently uses the open-source library libcurl for network requests, but does not call libcurl interfaces directly. Instead, a wrapper layer is implemented for Kotlin to call. The wrapper code is located in: ohosApp/pbcurlwrapper/.
 2. If you need to modify the logic of the wrapper layer, after making changes, build the artifact by executing Build/Make Module 'pbcurlwrapper' in DevEco-Studio. The artifact can be found in the temporary folder: pbcurlwrapper/build/default/intermediate/cmake/default/obj/arm64-v8a/libpbcurlwrapper.so.
-3. If you want to run the ohosApp demo project after modification, you can manually copy the .so file from the build folder to entry/libs/arm64-v8a/, overwriting the original .so file.
+3. If you want to run the ohosApp demo project after modification, you can manually copy libpbcurlwrapper.so from the build folder to entry/libs/arm64-v8a/, overwriting the original file.
+4. For external HarmonyOS app integration, follow [HarmonyOS Integration](./docs/harmonyos-integration.md) to configure permissions, native libraries, and CMake linkage.
 
 ### ChangeLog
 

--- a/NetworkKMM/README.md
+++ b/NetworkKMM/README.md
@@ -84,6 +84,39 @@ VBTransportInitHelper.init(config)
 ### Common Network Request Examples
 Some common HTTP GET/POST/string/byte/custom method request examples can be found in ***network/src/commonMain/service/VBTransportServiceTest.kt*** for your reference.
 
+#### Custom Method Request
+```kotlin
+val request = VBTransportRequest().apply {
+    method = VBTransportMethod.PUT
+    url = "https://httpbin.org/put"
+    header["Content-Type"] = VBTransportContentType.JSON.toString()
+    header["Authorization"] = "Bearer sample-token"
+    data = """{"name":"Kuikly","method":"PUT"}"""
+}
+
+VBTransportService.sendRequest(request) { response ->
+    println(response.data)
+}
+```
+
+#### Binary File Upload
+```kotlin
+val request = VBTransportRequest().apply {
+    method = VBTransportMethod.POST
+    url = "https://httpbin.org/post"
+    header["Content-Type"] = VBTransportContentType.BYTE.toString()
+    header["X-File-Name"] = "sample.bin"
+    data = fileBytes
+    totalTimeout = 10000
+}
+
+VBTransportService.sendRequest(request) { response ->
+    println(response.errorMessage)
+}
+```
+
+If your server requires multipart/form-data, build the multipart body bytes yourself and set the matching `Content-Type` boundary header before assigning the bytes to `data`.
+
 ### Demo Project Usage Instructions
 #### Android
 Simply run the androidApp target.

--- a/NetworkKMM/README.md
+++ b/NetworkKMM/README.md
@@ -115,7 +115,26 @@ VBTransportService.sendRequest(request) { response ->
 }
 ```
 
-If your server requires multipart/form-data, build the multipart body bytes yourself and set the matching `Content-Type` boundary header before assigning the bytes to `data`.
+#### Multipart File Upload
+```kotlin
+val multipartBody = VBTransportMultipartBodyBuilder()
+    .addFormField("name", "Kuikly")
+    .addFormField("uploadType", "multipart")
+    .addFile("file", "sample.bin", fileBytes, VBTransportContentType.BYTE.toString())
+    .build()
+
+val request = VBTransportRequest().apply {
+    method = VBTransportMethod.POST
+    url = "https://httpbin.org/post"
+    header["Authorization"] = "Bearer sample-token"
+    setMultipartBody(multipartBody)
+    totalTimeout = 10000
+}
+
+VBTransportService.sendRequest(request) { response ->
+    println(response.data)
+}
+```
 
 ### Demo Project Usage Instructions
 #### Android

--- a/NetworkKMM/README.md
+++ b/NetworkKMM/README.md
@@ -82,7 +82,7 @@ VBTransportInitHelper.init(config)
 ```
 
 ### Common Network Request Examples
-Some common HTTP GET/POST/string/byte request examples can be found in ***network/src/commonMain/service/VBTransportServiceTest.kt*** for your reference.
+Some common HTTP GET/POST/string/byte/custom method request examples can be found in ***network/src/commonMain/service/VBTransportServiceTest.kt*** for your reference.
 
 ### Demo Project Usage Instructions
 #### Android

--- a/NetworkKMM/docs/changelog.md
+++ b/NetworkKMM/docs/changelog.md
@@ -3,6 +3,7 @@
 ##### Unreleased
 
 - feature: support custom HTTP methods via VBTransportRequest
+- docs: add PUT and binary upload examples
 
 ##### 0.0.4
 

--- a/NetworkKMM/docs/changelog.md
+++ b/NetworkKMM/docs/changelog.md
@@ -1,5 +1,9 @@
 ### ChangeLog
 
+##### Unreleased
+
+- feature: support custom HTTP methods via VBTransportRequest
+
 ##### 0.0.4
 
 - feature: first publish

--- a/NetworkKMM/docs/changelog.md
+++ b/NetworkKMM/docs/changelog.md
@@ -5,6 +5,7 @@
 - feature: support custom HTTP methods via VBTransportRequest
 - feature: add multipart/form-data request body builder
 - docs: add PUT and binary upload examples
+- docs: add HarmonyOS native library integration guide
 
 ##### 0.0.4
 

--- a/NetworkKMM/docs/changelog.md
+++ b/NetworkKMM/docs/changelog.md
@@ -3,6 +3,7 @@
 ##### Unreleased
 
 - feature: support custom HTTP methods via VBTransportRequest
+- feature: add multipart/form-data request body builder
 - docs: add PUT and binary upload examples
 
 ##### 0.0.4

--- a/NetworkKMM/docs/harmonyos-integration.md
+++ b/NetworkKMM/docs/harmonyos-integration.md
@@ -1,0 +1,201 @@
+# KMM Network HarmonyOS 接入指南
+
+本文补充 HarmonyOS 侧接入 KMM Network 时必须处理的 native 库、权限、CMake 链接和初始化步骤。Android/iOS 主要接入 Kotlin 依赖和平台网络权限；HarmonyOS 侧底层通过 `pbcurlwrapper` 封装 libcurl，因此还需要额外集成 `.so` 文件。
+
+参考文档：[KMM Network 鸿蒙端接入使用指南](https://github.com/Kuikly-contrib/KuiklyLibGallery/blob/main/docs/KMM_Network_HarmonyOS_Integration_Guide.md)。
+
+## 1. 添加 Kotlin 依赖
+
+在 KMM 共享模块和 OHOS Gradle 配置中添加腾讯 Maven 仓库和 network 依赖，例如 `build.gradle.kts` / `build.ohos.gradle.kts`。
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://mirrors.tencent.com/nexus/repository/maven-tencent/")
+    }
+}
+
+dependencies {
+    implementation("com.tencent.kuiklybase:network:0.0.4")
+}
+```
+
+## 2. 声明 HarmonyOS 网络权限
+
+在 `ohosApp/entry/src/main/module.json5` 中添加网络权限。
+
+```json5
+{
+  "module": {
+    "requestPermissions": [
+      {
+        "name": "ohos.permission.INTERNET",
+        "reason": "$string:internet_permission_reason",
+        "usedScene": {
+          "abilities": ["EntryAbility"],
+          "when": "inuse"
+        }
+      },
+      {
+        "name": "ohos.permission.GET_NETWORK_INFO",
+        "reason": "$string:network_info_permission_reason",
+        "usedScene": {
+          "abilities": ["EntryAbility"],
+          "when": "inuse"
+        }
+      },
+      {
+        "name": "ohos.permission.GET_WIFI_INFO",
+        "reason": "$string:wifi_info_permission_reason",
+        "usedScene": {
+          "abilities": ["EntryAbility"],
+          "when": "inuse"
+        }
+      }
+    ]
+  }
+}
+```
+
+在 `ohosApp/entry/src/main/resources/base/element/string.json` 中补充权限说明字符串。
+
+```json
+{
+  "string": [
+    {
+      "name": "internet_permission_reason",
+      "value": "应用需要访问网络以获取数据"
+    },
+    {
+      "name": "network_info_permission_reason",
+      "value": "应用需要获取网络状态信息"
+    },
+    {
+      "name": "wifi_info_permission_reason",
+      "value": "应用需要获取 WiFi 信息"
+    }
+  ]
+}
+```
+
+## 3. 添加必需 Native 库
+
+HarmonyOS 接入必须包含以下 native 库：
+
+| 库文件 | 作用 | 下载链接 |
+| --- | --- | --- |
+| `libpbcurlwrapper.so` | KMM Network 调用 libcurl 的封装库 | [下载](https://drive.weixin.qq.com/s?k=AJEAIQdfAAoOl8vBYTAbQAJgZ2AA8) |
+| `libopenssl.so` | HTTPS/SSL/TLS 支持库 | [下载](https://drive.weixin.qq.com/s?k=AJEAIQdfAAohnXGmhhAbQAJgZ2AA8) |
+
+把两个文件放到 OHOS entry 模块的 native 库目录：
+
+```text
+ohosApp/
+└── entry/
+    └── libs/
+        └── arm64-v8a/
+            ├── libpbcurlwrapper.so
+            └── libopenssl.so
+```
+
+如果 `entry/libs/arm64-v8a/` 不存在，需要手动创建。本仓库 demo 已经在 `NetworkKMM/ohosApp/entry/libs/arm64-v8a/` 内置这两个文件；业务项目接入时仍需要把它们下载或拷贝到自己的 entry 模块。
+
+## 4. 链接 Native 库
+
+如果业务 OHOS app 有 native entry CMake target，需要在 `ohosApp/entry/src/main/cpp/CMakeLists.txt` 中导入并链接这两个库。
+
+```cmake
+add_library(pbcurlwrapper SHARED IMPORTED)
+set_target_properties(pbcurlwrapper
+    PROPERTIES
+    IMPORTED_LOCATION ${NATIVERENDER_ROOT_PATH}/../../../libs/${OHOS_ARCH}/libpbcurlwrapper.so
+)
+
+add_library(openssl SHARED IMPORTED)
+set_target_properties(openssl
+    PROPERTIES
+    IMPORTED_LOCATION ${NATIVERENDER_ROOT_PATH}/../../../libs/${OHOS_ARCH}/libopenssl.so
+)
+```
+
+然后在 `target_link_libraries` 中加入 `pbcurlwrapper` 和 `openssl`。
+
+```cmake
+target_link_libraries(entry PUBLIC
+    libace_napi.z.so
+    libhilog_ndk.z.so
+    kuikly_shared
+    kuikly_render
+    pbcurlwrapper
+    openssl
+)
+```
+
+如果 entry 模块使用 `externalNativeOptions`，需要确保 `build-profile.json5` 指向对应 CMake 文件，并限制 ABI 为 `arm64-v8a`，和下载的 native 库架构保持一致。
+
+```json5
+{
+  "buildOption": {
+    "externalNativeOptions": {
+      "path": "./src/main/cpp/CMakeLists.txt",
+      "abiFilters": ["arm64-v8a"]
+    }
+  }
+}
+```
+
+## 5. 初始化 KMM Network
+
+在第一次发起网络请求前初始化网络模块。推荐放在应用启动流程，或者首个 Kuikly 页面初始化阶段。
+
+```kotlin
+import com.tencent.kmm.network.export.IVBPBLog
+import com.tencent.kmm.network.export.VBTransportInitConfig
+import com.tencent.kmm.network.service.VBTransportInitHelper
+
+val logImpl = object : IVBPBLog {
+    override fun d(tag: String?, content: String?) {
+        println("[$tag] DEBUG: $content")
+    }
+
+    override fun i(tag: String?, content: String?) {
+        println("[$tag] INFO: $content")
+    }
+
+    override fun e(tag: String?, content: String?, throwable: Throwable?) {
+        println("[$tag] ERROR: $content")
+        throwable?.printStackTrace()
+    }
+}
+
+val config = VBTransportInitConfig()
+config.logImpl = logImpl
+VBTransportInitHelper.init(config)
+```
+
+## 6. 接入检查清单
+
+- [ ] 已添加 `com.tencent.kuiklybase:network:0.0.4`
+- [ ] 已添加腾讯 Maven 仓库
+- [ ] 已声明 `INTERNET`、`GET_NETWORK_INFO`、`GET_WIFI_INFO`
+- [ ] 已添加权限 reason 字符串
+- [ ] 已下载 `libpbcurlwrapper.so`
+- [ ] 已下载 `libopenssl.so`
+- [ ] 两个 `.so` 已放到 `entry/libs/arm64-v8a/`
+- [ ] 有 native entry target 时，已在 CMake 中添加 imported library
+- [ ] 有 native entry target 时，已链接 `pbcurlwrapper` 和 `openssl`
+- [ ] 已在发起请求前调用 `VBTransportInitHelper.init()`
+
+## 常见问题
+
+### 编译时报找不到 `.so`
+
+检查 `entry/libs/arm64-v8a/` 下是否存在 `libpbcurlwrapper.so` 和 `libopenssl.so`，文件名是否完全一致，以及 CMake 中 `IMPORTED_LOCATION` 是否指向 `../../../libs/${OHOS_ARCH}/`。
+
+### 运行时 native library not found
+
+确认运行设备是 ARM64，并且 entry target 已链接 `pbcurlwrapper` 和 `openssl`。当前下载库只覆盖 `arm64-v8a`，不支持 x86/x86_64 模拟器。
+
+### HTTPS 请求失败
+
+确认 `libopenssl.so` 已放置到正确目录，CMake 已链接 `openssl`，并检查设备系统时间是否正确。

--- a/NetworkKMM/network/src/androidMain/kotlin/com/tencent/kmm/network/curl/CurlRequestService.android.kt
+++ b/NetworkKMM/network/src/androidMain/kotlin/com/tencent/kmm/network/curl/CurlRequestService.android.kt
@@ -23,6 +23,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 
@@ -55,6 +57,14 @@ object CurlRequestServiceAndroid : ICurlRequestService {
     override fun sendBytesRequest(
         kmmBytesRequest: VBTransportBytesRequest,
         kmmBytesResponseCallback: (response: VBTransportBytesResponse) -> Unit,
+        logTag: String
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun request(
+        kmmRequest: VBTransportRequest,
+        kmmResponseCallback: (response: VBTransportResponse) -> Unit,
         logTag: String
     ) {
         TODO("Not yet implemented")

--- a/NetworkKMM/network/src/androidMain/kotlin/com/tencent/kmm/network/internal/platform/IVBTransportService.android.kt
+++ b/NetworkKMM/network/src/androidMain/kotlin/com/tencent/kmm/network/internal/platform/IVBTransportService.android.kt
@@ -25,6 +25,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 import com.tencent.kmm.network.internal.VBPBLog
@@ -33,18 +35,19 @@ import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.buildRespon
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapBytesCallback
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapGetCallback
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapPostCallback
+import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapRequestCallback
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapStringCallback
 import com.tencent.kmm.network.internal.utils.getHttpClient
 import com.tencent.kmm.network.internal.utils.readKnownSize
 import com.tencent.kmm.network.internal.utils.readUnknownSize
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.client.request.get
 import io.ktor.client.request.header
-import io.ktor.client.request.post
+import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentLength
 import io.ktor.http.contentType
@@ -63,14 +66,9 @@ object AndroidTransportImpl : IVBTransportService {
     ) {
         val job = scope.launch {
             val client = getHttpClient(request) as HttpClient
-            val response = if (request is VBTransportGetRequest || request is VBTransportStringRequest) {
-                client.get(request.url) {
-                    constructRequest(request)
-                }
-            } else {
-                client.post(request.url) {
-                    constructRequest(request)
-                }
+            val response = client.request(request.url) {
+                method = HttpMethod(request.method.name)
+                constructRequest(request)
             }
 
             var errMsg = ""
@@ -144,6 +142,15 @@ object AndroidTransportImpl : IVBTransportService {
         triggerRequest(kmmGetRequest, wrapGetCallback(kmmGetResponseCallback))
     }
 
+    override fun request(
+        kmmRequest: VBTransportRequest,
+        kmmResponseCallback: (response: VBTransportResponse) -> Unit
+    ) {
+        logI("send ${kmmRequest.method} request, id:${kmmRequest.requestId}, url:${kmmRequest.url}, " +
+                "header:${kmmRequest.header}", kmmRequest.logTag)
+        triggerRequest(kmmRequest, wrapRequestCallback(kmmResponseCallback))
+    }
+
     private fun HttpRequestBuilder.constructRequest(kmmRequest: VBTransportBaseRequest) {
         // 设置 header
         kmmRequest.header
@@ -151,10 +158,8 @@ object AndroidTransportImpl : IVBTransportService {
             .forEach { (k, v) -> header(k, v) }
 
         // 设置 post body
-        if (kmmRequest is VBTransportBytesRequest) {
-            setBody(kmmRequest.data)
-        } else if (kmmRequest is VBTransportPostRequest) {
-            setBody(kmmRequest.data)
+        kmmRequest.bodyData()?.let {
+            setBody(it)
         }
 
         val requestContentType = kmmRequest.header["Content-Type"]?.let { contentType ->

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/curl/CurlRequestService.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/curl/CurlRequestService.kt
@@ -23,6 +23,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 
@@ -57,6 +59,14 @@ object CurlRequestService {
         logTag: String
     ) {
         getCurlRequestService().sendBytesRequest(request, handler, logTag)
+    }
+
+    fun sendRequest(
+        request: VBTransportRequest,
+        handler: ((response: VBTransportResponse) -> Unit),
+        logTag: String
+    ) {
+        getCurlRequestService().request(request, handler, logTag)
     }
 
     fun cancel(requestId: Int) {

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/curl/ICurlRequestService.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/curl/ICurlRequestService.kt
@@ -23,6 +23,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 
@@ -60,6 +62,15 @@ interface ICurlRequestService {
     fun sendBytesRequest(
         kmmBytesRequest: VBTransportBytesRequest,
         kmmBytesResponseCallback: (response: VBTransportBytesResponse) -> Unit,
+        logTag: String
+    )
+
+    /**
+     * 发送自定义 HTTP method 请求
+     */
+    fun request(
+        kmmRequest: VBTransportRequest,
+        kmmResponseCallback: (response: VBTransportResponse) -> Unit,
         logTag: String
     )
 

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/export/VBTransportCompletionHandler.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/export/VBTransportCompletionHandler.kt
@@ -20,3 +20,4 @@ typealias VBTransportStringCompletionHandler = (response: VBTransportStringRespo
 typealias VBTransportBytesCompletionHandler = (response: VBTransportBytesResponse) -> Unit
 typealias VBTransportPostHandler = (response: VBTransportPostResponse) -> Unit
 typealias VBTransportGetHandler = (response: VBTransportGetResponse) -> Unit
+typealias VBTransportHandler = (response: VBTransportResponse) -> Unit

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/export/VBTransportRequest.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/export/VBTransportRequest.kt
@@ -17,7 +17,7 @@
 package com.tencent.kmm.network.export
 
 enum class VBTransportMethod {
-    GET, POST
+    GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
 }
 
 enum class VBTransportContentType(private val description: String) {
@@ -32,24 +32,51 @@ open class VBTransportBaseRequest {
     var header = mutableMapOf<String, String>()
     var logTag: String = ""
     var url: String = ""
+    var method: VBTransportMethod = VBTransportMethod.GET
     var quicForceQuic = false
     var totalTimeout: Long = 0L
     // 底层是否使用 libcurl 进行请求
     var useCurl: Boolean = true
+
+    internal open fun bodyData(): Any? = null
 }
 
 class VBTransportStringRequest : VBTransportBaseRequest() {
+    init {
+        method = VBTransportMethod.GET
+    }
 }
 
 class VBTransportBytesRequest : VBTransportBaseRequest() {
     var data: ByteArray = byteArrayOf()
+
+    init {
+        method = VBTransportMethod.POST
+    }
+
+    internal override fun bodyData(): Any = data
 }
 
 class VBTransportPostRequest : VBTransportBaseRequest() {
     lateinit var data: Any
 
+    init {
+        method = VBTransportMethod.POST
+    }
+
     fun isDataInitialize(): Boolean = this::data.isInitialized
+
+    internal override fun bodyData(): Any? = if (isDataInitialize()) data else null
 }
 
 class VBTransportGetRequest : VBTransportBaseRequest() {
+    init {
+        method = VBTransportMethod.GET
+    }
+}
+
+class VBTransportRequest : VBTransportBaseRequest() {
+    var data: Any? = null
+
+    internal override fun bodyData(): Any? = data
 }

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/export/VBTransportRequest.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/export/VBTransportRequest.kt
@@ -16,6 +16,8 @@
  */
 package com.tencent.kmm.network.export
 
+import kotlin.random.Random
+
 enum class VBTransportMethod {
     GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS
 }
@@ -26,6 +28,81 @@ enum class VBTransportContentType(private val description: String) {
 
     override fun toString(): String = description
 }
+
+class VBTransportMultipartBody(
+    val boundary: String,
+    val contentType: String,
+    val data: ByteArray
+)
+
+class VBTransportMultipartBodyBuilder(
+    private val boundary: String = defaultMultipartBoundary()
+) {
+    private val chunks = mutableListOf<ByteArray>()
+
+    fun addFormField(
+        name: String,
+        value: String
+    ): VBTransportMultipartBodyBuilder {
+        appendString("--$boundary\r\n")
+        appendString("Content-Disposition: form-data; name=\"${sanitizeHeaderValue(name)}\"\r\n")
+        appendString("\r\n")
+        appendString(value)
+        appendString("\r\n")
+        return this
+    }
+
+    fun addFile(
+        name: String,
+        fileName: String,
+        bytes: ByteArray,
+        contentType: String = VBTransportContentType.BYTE.toString()
+    ): VBTransportMultipartBodyBuilder {
+        appendString("--$boundary\r\n")
+        appendString(
+            "Content-Disposition: form-data; name=\"${sanitizeHeaderValue(name)}\"; " +
+                    "filename=\"${sanitizeHeaderValue(fileName)}\"\r\n"
+        )
+        appendString("Content-Type: $contentType\r\n")
+        appendString("\r\n")
+        chunks.add(bytes)
+        appendString("\r\n")
+        return this
+    }
+
+    fun build(): VBTransportMultipartBody {
+        val body = mergeChunks(chunks + "--$boundary--\r\n".encodeToByteArray())
+        return VBTransportMultipartBody(
+            boundary = boundary,
+            contentType = "multipart/form-data; boundary=$boundary",
+            data = body
+        )
+    }
+
+    private fun appendString(value: String) {
+        chunks.add(value.encodeToByteArray())
+    }
+
+    private fun sanitizeHeaderValue(value: String): String =
+        value.replace("\"", "%22")
+            .replace("\r", "")
+            .replace("\n", "")
+
+    private fun mergeChunks(chunks: List<ByteArray>): ByteArray {
+        var totalSize = 0
+        chunks.forEach { totalSize += it.size }
+        val result = ByteArray(totalSize)
+        var offset = 0
+        chunks.forEach { chunk ->
+            chunk.copyInto(result, destinationOffset = offset)
+            offset += chunk.size
+        }
+        return result
+    }
+}
+
+private fun defaultMultipartBoundary(): String =
+    "KuiklyNetworkBoundary${Random.nextInt(0, Int.MAX_VALUE)}"
 
 open class VBTransportBaseRequest {
     var requestId: Int = 0
@@ -79,4 +156,9 @@ class VBTransportRequest : VBTransportBaseRequest() {
     var data: Any? = null
 
     internal override fun bodyData(): Any? = data
+}
+
+fun VBTransportRequest.setMultipartBody(body: VBTransportMultipartBody) {
+    header["Content-Type"] = body.contentType
+    data = body.data
 }

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/export/VBTransportResponse.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/export/VBTransportResponse.kt
@@ -45,3 +45,7 @@ class VBTransportGetResponse : VBTransportBaseResponse() {
     lateinit var request: VBTransportGetRequest
 }
 
+class VBTransportResponse : VBTransportBaseResponse() {
+    var data: Any? = null
+    lateinit var request: VBTransportRequest
+}

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/internal/VBTransportTask.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/internal/VBTransportTask.kt
@@ -27,6 +27,9 @@ import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostHandler
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportHandler
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportResultCode
 import com.tencent.kmm.network.export.VBTransportStringCompletionHandler
 import com.tencent.kmm.network.export.VBTransportStringRequest
@@ -79,6 +82,16 @@ class VBTransportTask(
         return { response ->
             val res = response as? VBTransportBytesResponse
             res?.let { bytesCallback(it) }
+        }
+    }
+
+    private fun wrapResponse(
+        callback: ((response: VBTransportResponse) -> Unit)?
+    ): ((baseResponse: VBTransportBaseResponse) -> Unit)? {
+        callback ?: return null
+        return { response ->
+            val res = response as? VBTransportResponse
+            res?.let { callback(it) }
         }
     }
 
@@ -196,6 +209,29 @@ class VBTransportTask(
         state = VBTransportState.Running
         getIVBTransportService().get(request) { response ->
             handleResponse(request, response, wrapGetResponse(handler))
+        }
+    }
+
+    fun sendRequest(
+        request: VBTransportRequest,
+        handler: VBTransportHandler?
+    ) {
+        if (isCanceledOrRemoved()) {
+            val response = VBTransportResponse()
+            logI("execute() request task is canceled before")
+            handler?.let {
+                response.errorCode = VBTransportResultCode.CODE_CANCELED
+                response.errorMessage = "请求已被取消"
+                logI("execute() invoke failHandler，task has been canceled")
+                it(response)
+            } ?: run {
+                logI("task has been canceled and handler is null!")
+            }
+            return
+        }
+        state = VBTransportState.Running
+        getIVBTransportService().request(request) { response ->
+            handleResponse(request, response, wrapResponse(handler))
         }
     }
 

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/internal/VBTransportTask.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/internal/VBTransportTask.kt
@@ -221,7 +221,7 @@ class VBTransportTask(
             logI("execute() request task is canceled before")
             handler?.let {
                 response.errorCode = VBTransportResultCode.CODE_CANCELED
-                response.errorMessage = "请求已被取消"
+                response.errorMessage = "Request has been canceled"
                 logI("execute() invoke failHandler，task has been canceled")
                 it(response)
             } ?: run {

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/internal/platform/IVBTransportService.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/internal/platform/IVBTransportService.kt
@@ -22,6 +22,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 
@@ -56,6 +58,14 @@ interface IVBTransportService {
     fun get(
         kmmGetRequest: VBTransportGetRequest,
         kmmGetResponseCallback: (response: VBTransportGetResponse) -> Unit
+    )
+
+    /**
+     * 发送自定义 HTTP method 请求
+     */
+    fun request(
+        kmmRequest: VBTransportRequest,
+        kmmResponseCallback: (response: VBTransportResponse) -> Unit
     )
 
     /**

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/internal/utils/VBTransportCommonUtils.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/internal/utils/VBTransportCommonUtils.kt
@@ -25,6 +25,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 import com.tencent.kmm.network.internal.VBPBLog
@@ -78,6 +80,17 @@ object VBTransportCommonUtils {
         }
     }
 
+    fun wrapRequestCallback(
+        callback: (VBTransportResponse) -> Unit
+    ): (VBTransportBaseResponse) -> Unit {
+        return { baseResponse ->
+            val response = baseResponse as? VBTransportResponse
+            response?.let { callback(it) } ?: run {
+                VBPBLog.i(TAG, "wrapRequestCallback response is null !!!")
+            }
+        }
+    }
+
     fun buildResponseAndCallback(
         taskMap: MutableMap<Int, Job>,
         errorCode: Int,
@@ -89,7 +102,13 @@ object VBTransportCommonUtils {
     ) {
         VBPBLog.i(TAG, "${request.logTag} receive response, errCode:${errorCode}, " +
                 "errMsg:${errorMsg}, headers:${headers}, data size:${data.size}")
-        if (request is VBTransportGetRequest) {
+        if (request is VBTransportRequest) {
+            // 自定义 method 请求回调
+            val kmmResponse = VBTransportResponse().apply {
+                updateResponse(errorCode, errorMsg, headers, data, request, this)
+            }
+            kmmCallback(kmmResponse)
+        } else if (request is VBTransportGetRequest) {
             // Get 请求回调
             val kmmGetResponse = VBTransportGetResponse().apply {
                 updateResponse(errorCode, errorMsg, headers, data, request, this)
@@ -147,6 +166,11 @@ object VBTransportCommonUtils {
             is VBTransportStringResponse -> {
                 response.data = data.decodeToString()
                 response.request = request as VBTransportStringRequest
+            }
+
+            is VBTransportResponse -> {
+                response.data = convertDataWithContentType(data, request)
+                response.request = request as VBTransportRequest
             }
         }
     }

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportService.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportService.kt
@@ -26,6 +26,9 @@ import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostHandler
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportHandler
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportResultCode
 import com.tencent.kmm.network.export.VBTransportStringCompletionHandler
 import com.tencent.kmm.network.export.VBTransportStringRequest
@@ -140,6 +143,31 @@ object VBTransportService {
         }
         startTimeoutCheckTask(request.totalTimeout, request.requestId, request) {
             val timeoutResponse = VBTransportGetResponse().apply {
+                this.request = request
+                this.errorCode = VBTransportResultCode.CODE_FORCE_TIMEOUT
+                this.errorMessage = "请求超时"
+            }
+            handler?.invoke(timeoutResponse)
+        }
+    }
+
+    fun sendRequest(
+        request: VBTransportRequest,
+        handler: VBTransportHandler?
+    ) {
+        request.requestId = VBPBRequestIdGenerator.getRequestId()
+        networkScope.launch(track = true) {
+            val task = VBTransportTask(request.requestId, request.useCurl, request.logTag, taskManager)
+            taskManager.onTaskBegin(task)
+            task.sendRequest(request) { response ->
+                if (task.getState() != VBTransportState.Done) {
+                    task.setState(VBTransportState.Done)
+                    handler?.let { it(response) }
+                }
+            }
+        }
+        startTimeoutCheckTask(request.totalTimeout, request.requestId, request) {
+            val timeoutResponse = VBTransportResponse().apply {
                 this.request = request
                 this.errorCode = VBTransportResultCode.CODE_FORCE_TIMEOUT
                 this.errorMessage = "请求超时"

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportService.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportService.kt
@@ -170,7 +170,7 @@ object VBTransportService {
             val timeoutResponse = VBTransportResponse().apply {
                 this.request = request
                 this.errorCode = VBTransportResultCode.CODE_FORCE_TIMEOUT
-                this.errorMessage = "请求超时"
+                this.errorMessage = "Request timed out"
             }
             handler?.invoke(timeoutResponse)
         }

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportServiceTest.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportServiceTest.kt
@@ -20,7 +20,9 @@ import com.tencent.kmm.network.export.IVBPBLog
 import com.tencent.kmm.network.export.VBTransportBytesRequest
 import com.tencent.kmm.network.export.VBTransportContentType
 import com.tencent.kmm.network.export.VBTransportGetRequest
+import com.tencent.kmm.network.export.VBTransportMethod
 import com.tencent.kmm.network.export.VBTransportPostRequest
+import com.tencent.kmm.network.export.VBTransportRequest
 import com.tencent.kmm.network.export.VBTransportResultCode
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.internal.VBPBLog
@@ -347,6 +349,28 @@ object VBTransportServiceTest {
                 "[TRACE]",
                 "302 response code:${it.errorCode}, message:${it.errorMessage}, url:${it.request.url}, " +
                         "header:${it.header}, data:${it.data}, request: ${it.request}, server ip:${it.serverIP}, port:${it.serverPort}"
+            )
+        }
+    }
+
+    @ObjCName("testSendPatchRequest")
+    fun testSendPatchRequest(
+        logTag: String = "TestKMMPatchRequest",
+        useCurl: Boolean = false
+    ) {
+        val request = VBTransportRequest()
+        request.method = VBTransportMethod.PATCH
+        request.url = "https://httpbin.org/patch"
+        request.logTag = logTag
+        request.header["Content-Type"] = VBTransportContentType.JSON.toString()
+        request.data = """{"name":"Kuikly","method":"PATCH"}"""
+        request.useCurl = useCurl
+        VBTransportService.sendRequest(request) {
+            val responseData = convertResponseData(it.data)
+            VBPBLog.i(
+                "[TRACE]",
+                "patch response code:${it.errorCode}, message:${it.errorMessage}, " +
+                        "size:${responseData.len}, data:${responseData.content}, request: ${it.request}"
             )
         }
     }

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportServiceTest.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportServiceTest.kt
@@ -21,10 +21,12 @@ import com.tencent.kmm.network.export.VBTransportBytesRequest
 import com.tencent.kmm.network.export.VBTransportContentType
 import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportMethod
+import com.tencent.kmm.network.export.VBTransportMultipartBodyBuilder
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportRequest
 import com.tencent.kmm.network.export.VBTransportResultCode
 import com.tencent.kmm.network.export.VBTransportStringRequest
+import com.tencent.kmm.network.export.setMultipartBody
 import com.tencent.kmm.network.internal.VBPBLog
 import kotlin.experimental.ExperimentalObjCName
 import kotlin.native.ObjCName
@@ -420,6 +422,35 @@ object VBTransportServiceTest {
             VBPBLog.i(
                 "[TRACE]",
                 "upload response code:${it.errorCode}, message:${it.errorMessage}, " +
+                        "size:${responseData.len}, data:${responseData.content}, request: ${it.request}"
+            )
+        }
+    }
+
+    @ObjCName("testUploadMultipartFileRequest")
+    fun testUploadMultipartFileRequest(
+        logTag: String = "TestKMMUploadMultipartFileRequest",
+        useCurl: Boolean = false
+    ) {
+        val multipartBody = VBTransportMultipartBodyBuilder()
+            .addFormField("name", "Kuikly")
+            .addFormField("uploadType", "multipart")
+            .addFile("file", "sample.bin", byteData, VBTransportContentType.BYTE.toString())
+            .build()
+
+        val request = VBTransportRequest()
+        request.method = VBTransportMethod.POST
+        request.url = "https://httpbin.org/post"
+        request.logTag = logTag
+        request.header["Authorization"] = "Bearer sample-token"
+        request.setMultipartBody(multipartBody)
+        request.useCurl = useCurl
+        request.totalTimeout = 10000
+        VBTransportService.sendRequest(request) {
+            val responseData = convertResponseData(it.data)
+            VBPBLog.i(
+                "[TRACE]",
+                "multipart upload response code:${it.errorCode}, message:${it.errorMessage}, " +
                         "size:${responseData.len}, data:${responseData.content}, request: ${it.request}"
             )
         }

--- a/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportServiceTest.kt
+++ b/NetworkKMM/network/src/commonMain/kotlin/com/tencent/kmm/network/service/VBTransportServiceTest.kt
@@ -375,6 +375,56 @@ object VBTransportServiceTest {
         }
     }
 
+    @ObjCName("testSendPutRequest")
+    fun testSendPutRequest(
+        logTag: String = "TestKMMPutRequest",
+        useCurl: Boolean = false
+    ) {
+        val request = VBTransportRequest()
+        request.method = VBTransportMethod.PUT
+        request.url = "https://httpbin.org/put"
+        request.logTag = logTag
+        request.header["Content-Type"] = VBTransportContentType.JSON.toString()
+        request.header["Authorization"] = "Bearer sample-token"
+        request.header["X-Request-Source"] = "NetworkKMM"
+        request.data = """{"name":"Kuikly","method":"PUT"}"""
+        request.useCurl = useCurl
+        request.totalTimeout = 5000
+        VBTransportService.sendRequest(request) {
+            val responseData = convertResponseData(it.data)
+            VBPBLog.i(
+                "[TRACE]",
+                "put response code:${it.errorCode}, message:${it.errorMessage}, " +
+                        "size:${responseData.len}, data:${responseData.content}, request: ${it.request}"
+            )
+        }
+    }
+
+    @ObjCName("testUploadFileRequest")
+    fun testUploadFileRequest(
+        logTag: String = "TestKMMUploadFileRequest",
+        useCurl: Boolean = false
+    ) {
+        val request = VBTransportRequest()
+        request.method = VBTransportMethod.POST
+        request.url = "https://httpbin.org/post"
+        request.logTag = logTag
+        request.header["Content-Type"] = VBTransportContentType.BYTE.toString()
+        request.header["Authorization"] = "Bearer sample-token"
+        request.header["X-File-Name"] = "sample.bin"
+        request.data = byteData
+        request.useCurl = useCurl
+        request.totalTimeout = 10000
+        VBTransportService.sendRequest(request) {
+            val responseData = convertResponseData(it.data)
+            VBPBLog.i(
+                "[TRACE]",
+                "upload response code:${it.errorCode}, message:${it.errorMessage}, " +
+                        "size:${responseData.len}, data:${responseData.content}, request: ${it.request}"
+            )
+        }
+    }
+
     @ObjCName("testCancelRequest")
     fun testCancelRequest() {
         // 以 Post 为例

--- a/NetworkKMM/network/src/iosMain/kotlin/com/tencent/kmm/network/curl/CurlRequestService.ios.kt
+++ b/NetworkKMM/network/src/iosMain/kotlin/com/tencent/kmm/network/curl/CurlRequestService.ios.kt
@@ -23,6 +23,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 
@@ -55,6 +57,14 @@ object CurlRequestServiceIOS : ICurlRequestService {
     override fun sendBytesRequest(
         kmmBytesRequest: VBTransportBytesRequest,
         kmmBytesResponseCallback: (response: VBTransportBytesResponse) -> Unit,
+        logTag: String
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun request(
+        kmmRequest: VBTransportRequest,
+        kmmResponseCallback: (response: VBTransportResponse) -> Unit,
         logTag: String
     ) {
         TODO("Not yet implemented")

--- a/NetworkKMM/network/src/iosMain/kotlin/com/tencent/kmm/network/internal/platform/IVBTransportService.ios.kt
+++ b/NetworkKMM/network/src/iosMain/kotlin/com/tencent/kmm/network/internal/platform/IVBTransportService.ios.kt
@@ -25,6 +25,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 import com.tencent.kmm.network.internal.VBPBLog
@@ -33,18 +35,19 @@ import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.buildRespon
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapBytesCallback
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapGetCallback
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapPostCallback
+import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapRequestCallback
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapStringCallback
 import com.tencent.kmm.network.internal.utils.getHttpClient
 import com.tencent.kmm.network.internal.utils.readKnownSize
 import com.tencent.kmm.network.internal.utils.readUnknownSize
 import io.ktor.client.HttpClient
 import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.client.request.get
 import io.ktor.client.request.header
-import io.ktor.client.request.post
+import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.http.ContentType
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentLength
 import io.ktor.http.contentType
@@ -66,16 +69,9 @@ class IOSTransportImpl : IVBTransportService {
     ) {
         val job = scope.launch {
             val client = getHttpClient(request) as HttpClient
-            val response = when (request) {
-                is VBTransportGetRequest, is VBTransportStringRequest ->
-                    client.get(request.url) {
-                        constructRequest(request)
-                    }
-
-                else ->
-                    client.post(request.url) {
-                        constructRequest(request)
-                    }
+            val response = client.request(request.url) {
+                method = HttpMethod(request.method.name)
+                constructRequest(request)
             }
 
             var errMsg = ""
@@ -151,12 +147,20 @@ class IOSTransportImpl : IVBTransportService {
         startRequest(kmmGetRequest, wrapGetCallback(kmmGetResponseCallback))
     }
 
+    override fun request(
+        kmmRequest: VBTransportRequest,
+        kmmResponseCallback: (response: VBTransportResponse) -> Unit
+    ) {
+        VBPBLog.i(VBPBLog.HMTRANSPORTIMPL, "${kmmRequest.logTag} send ${kmmRequest.method} request, " +
+                "id:${kmmRequest.requestId}, url:${kmmRequest.url}, " +
+                "header:${kmmRequest.header}")
+        startRequest(kmmRequest, wrapRequestCallback(kmmResponseCallback))
+    }
+
     private fun HttpRequestBuilder.constructRequest(kmmRequest: VBTransportBaseRequest) {
         // 设置 post body
-        if (kmmRequest is VBTransportPostRequest) {
-            setBody(kmmRequest.data)
-        } else if (kmmRequest is VBTransportBytesRequest) {
-            setBody(kmmRequest.data)
+        kmmRequest.bodyData()?.let {
+            setBody(it)
         }
 
         kmmRequest.header.forEach {

--- a/NetworkKMM/network/src/ohosArm64Main/kotlin/com/tencent/kmm/network/curl/CurlRequestService.ohosArm64.kt
+++ b/NetworkKMM/network/src/ohosArm64Main/kotlin/com/tencent/kmm/network/curl/CurlRequestService.ohosArm64.kt
@@ -21,6 +21,7 @@ import com.tencent.kmm.network.internal.VBPBLog
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapBytesCallback
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapGetCallback
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapPostCallback
+import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapRequestCallback
 import com.tencent.kmm.network.internal.utils.VBTransportCommonUtils.wrapStringCallback
 import com.tencent.qqlive.kmm.native.libcurl.Cancel
 import com.tencent.qqlive.kmm.native.libcurl.CreateCurlClient
@@ -42,6 +43,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 import kotlinx.cinterop.ByteVar
@@ -153,41 +156,35 @@ object CurlRequestServiceHM : ICurlRequestService {
     ): CValue<CurlRequest> {
         return cValue<CurlRequest> {
             this.url = toCSTR(request.url, memScope)
+            this.method = toCSTR(request.method.name, memScope)
             this.headers = headers.ptr
             this.timeout = request.totalTimeout
             this.postBodyLen = 0
-            if (request is VBTransportPostRequest && request.isDataInitialize()) {
-                if (request.data is ByteArray) {
-                    val byteData = (request.data as ByteArray)
-                    logI("[$logTag] generate native Post curl params with bytearray data. " +
-                            "size: ${byteData.size}, data: $byteData")
-                    val buffer = nativeHeap.allocArray<int8_tVar>(byteData.size)
-                    if (byteData.isNotEmpty()) {
-                        byteData.usePinned { pinnedData ->
-                            memcpy(buffer, pinnedData.addressOf(0), byteData.size.convert())
+            when (val data = request.bodyData()) {
+                is ByteArray -> {
+                    logI("[$logTag] generate native ${request.method} curl params with bytearray data. " +
+                            "size: ${data.size}, data: $data")
+                    val buffer = nativeHeap.allocArray<int8_tVar>(data.size)
+                    if (data.isNotEmpty()) {
+                        data.usePinned { pinnedData ->
+                            memcpy(buffer, pinnedData.addressOf(0), data.size.convert())
                         }
                     }
-                    this.postBodyLen = byteData.size
+                    this.postBodyLen = data.size
                     this.postBody = buffer
-                } else {
-                    // String 类型
-                    val strData = (request.data as? String) ?: ""
+                }
+
+                null -> {
+                    // no body
+                }
+
+                else -> {
+                    val strData = data.toString()
                     this.postBodyLen = strData.encodeToByteArray().size
                     this.postBody = toCSTR(strData, memScope)
-                    logI("[$logTag] generate native Post params with string data. " +
+                    logI("[$logTag] generate native ${request.method} params with string data. " +
                             "size: ${postBodyLen}, data: $strData")
                 }
-            } else if (request is VBTransportBytesRequest) {
-                logI("[$logTag] generate native Bytes curl params with bytearray data. " +
-                        "size: ${request.data.size}, data: ${request.data}")
-                val buffer = nativeHeap.allocArray<int8_tVar>(request.data.size)
-                if (request.data.isNotEmpty()) {
-                    request.data.usePinned { pinnedData ->
-                        memcpy(buffer, pinnedData.addressOf(0), request.data.size.convert())
-                    }
-                }
-                this.postBodyLen = request.data.size
-                this.postBody = buffer
             }
         }
     }
@@ -230,6 +227,16 @@ object CurlRequestServiceHM : ICurlRequestService {
         logI("[${logTag}] send byte request, id: ${kmmBytesRequest.requestId}, " +
                 "url: ${kmmBytesRequest.url}, header: ${kmmBytesRequest.header}")
         startRequest(kmmBytesRequest, wrapBytesCallback(kmmBytesResponseCallback), logTag)
+    }
+
+    override fun request(
+        kmmRequest: VBTransportRequest,
+        kmmResponseCallback: (response: VBTransportResponse) -> Unit,
+        logTag: String
+    ) {
+        logI("[${logTag}] send ${kmmRequest.method} request, id: ${kmmRequest.requestId}, " +
+                "url: ${kmmRequest.url}, header: ${kmmRequest.header}")
+        startRequest(kmmRequest, wrapRequestCallback(kmmResponseCallback), logTag)
     }
 
     private fun buildPBRequestHeader(headers: Map<String, String>): Map<String, String> {
@@ -336,7 +343,13 @@ object CurlRequestServiceHM : ICurlRequestService {
         nativeResponse: CurlNativeResponse,
         responseCallback: (response: VBTransportBaseResponse) -> Unit
     ) {
-        if (request is VBTransportGetRequest) {
+        if (request is VBTransportRequest) {
+            // 自定义 method 请求回调
+            val kmmResponse = VBTransportResponse().apply {
+                updateResponse(request.logTag, nativeResponse, request, this)
+            }
+            responseCallback(kmmResponse)
+        } else if (request is VBTransportGetRequest) {
             // Get 请求回调
             val kmmGetResponse = VBTransportGetResponse().apply {
                 updateResponse(request.logTag, nativeResponse, request, this)
@@ -399,6 +412,11 @@ object CurlRequestServiceHM : ICurlRequestService {
             is VBTransportStringResponse -> {
                 data?.let { response.data = data as String }
                 response.request = request as VBTransportStringRequest
+            }
+
+            is VBTransportResponse -> {
+                response.data = data
+                response.request = request as VBTransportRequest
             }
         }
     }

--- a/NetworkKMM/network/src/ohosArm64Main/kotlin/com/tencent/kmm/network/internal/platform/IVBTransportService.ohosArm64.kt
+++ b/NetworkKMM/network/src/ohosArm64Main/kotlin/com/tencent/kmm/network/internal/platform/IVBTransportService.ohosArm64.kt
@@ -23,6 +23,8 @@ import com.tencent.kmm.network.export.VBTransportGetRequest
 import com.tencent.kmm.network.export.VBTransportGetResponse
 import com.tencent.kmm.network.export.VBTransportPostRequest
 import com.tencent.kmm.network.export.VBTransportPostResponse
+import com.tencent.kmm.network.export.VBTransportRequest
+import com.tencent.kmm.network.export.VBTransportResponse
 import com.tencent.kmm.network.export.VBTransportStringRequest
 import com.tencent.kmm.network.export.VBTransportStringResponse
 import com.tencent.kmm.network.internal.VBPBLog
@@ -66,6 +68,16 @@ object HmTransportImpl : IVBTransportService {
 
         // 使用 libcurl 进行请求
         CurlRequestService.sendGetRequest(kmmGetRequest, kmmGetResponseCallback, logTag)
+    }
+
+    override fun request(
+        kmmRequest: VBTransportRequest,
+        kmmResponseCallback: (response: VBTransportResponse) -> Unit
+    ) {
+        val logTag = kmmRequest.logTag + "_" + kmmRequest.requestId
+
+        // 使用 libcurl 进行请求
+        CurlRequestService.sendRequest(kmmRequest, kmmResponseCallback, logTag)
     }
 
     override fun cancel(requestId: Int) {

--- a/NetworkKMM/ohosApp/pbcurlwrapper/src/main/cpp/wrapper/include/curl_wrapper.h
+++ b/NetworkKMM/ohosApp/pbcurlwrapper/src/main/cpp/wrapper/include/curl_wrapper.h
@@ -62,6 +62,7 @@ typedef struct {
 // Curl 请求信息
 typedef struct {
     const char *url;
+    const char *method;
     StringDic *headers;
     int64_t timeout;  // 单位 ms
     int postBodyLen;

--- a/NetworkKMM/ohosApp/pbcurlwrapper/src/main/cpp/wrapper/src/curl_wrapper.cpp
+++ b/NetworkKMM/ohosApp/pbcurlwrapper/src/main/cpp/wrapper/src/curl_wrapper.cpp
@@ -16,6 +16,8 @@
  */
 
 #include "curl_wrapper.h"
+#include <algorithm>
+#include <cctype>
 #include <string>
 #include "curl/curl.h"
 #include "log/curl_log.h"
@@ -188,8 +190,13 @@ class CurlClient {
         int size = headers->size;
         int postBodyLen = request.postBodyLen;
         const char *postBody = request.postBody;
-        logI(log_tag_, "libcurl ver:" + curlVer + ", request url:" + url + ", header size:" + std::to_string(size)
-            + ", timeout:" + std::to_string(timeout));
+        std::string method = request.method == nullptr ? "" : request.method;
+        if (method.empty()) {
+            method = postBodyLen > 0 && postBody != nullptr ? "POST" : "GET";
+        }
+        std::transform(method.begin(), method.end(), method.begin(), ::toupper);
+        logI(log_tag_, "libcurl ver:" + curlVer + ", request method:" + method + ", request url:" + url
+            + ", header size:" + std::to_string(size) + ", timeout:" + std::to_string(timeout));
 
         // 拼接 Header
         for (int i = 0; i < size; i++) {
@@ -247,12 +254,19 @@ class CurlClient {
         curl_easy_setopt(curl_, CURLOPT_XFERINFODATA, this);
         curl_easy_setopt(curl_, CURLOPT_NOPROGRESS, 0L);
 
-        // 根据post body长度是否大于0, 判断是否是post请求
-        if (postBodyLen > 0 && postBody != nullptr) {
-            logI(log_tag_, "curl post request, body len:" + std::to_string(postBodyLen) + ", body:" + postBody);
+        if (method == "POST") {
+            curl_easy_setopt(curl_, CURLOPT_POST, 1L);
+        } else if (method == "HEAD") {
+            curl_easy_setopt(curl_, CURLOPT_NOBODY, 1L);
+        } else if (method != "GET") {
+            curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, method.c_str());
+        }
+
+        // Body is supported for POST and custom methods such as PUT/PATCH/DELETE.
+        if (method != "GET" && method != "HEAD" && postBodyLen > 0 && postBody != nullptr) {
+            logI(log_tag_, "curl " + method + " request, body len:" + std::to_string(postBodyLen));
             // size of the POST input data
             curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, postBodyLen);
-            curl_easy_setopt(curl_, CURLOPT_POST, 1L);
             if (postBodyLen >= 8 * 1024 * 1024) {
                 logI(log_tag_, "Enter above 8MB branch.");
                 // 传 body 指针，不会拷贝数据，因此必须确保 perform 之前数据有效


### PR DESCRIPTION
## Summary
- add VBTransportRequest/VBTransportResponse for custom HTTP methods
- support GET, POST, PUT, PATCH, DELETE, HEAD, and OPTIONS across Android, iOS, and OHOS paths
- pass the selected method through the OHOS libcurl wrapper and keep existing get/post APIs compatible

## Verification
- GRADLE_USER_HOME=/tmp/codex-gradle-kuiklybase JAVA_HOME=$(/usr/libexec/java_home -v 22) ./gradlew :network:compileCommonMainKotlinMetadata --no-daemon
- GRADLE_USER_HOME=/tmp/codex-gradle-kuiklybase JAVA_HOME=$(/usr/libexec/java_home -v 22) ./gradlew :network:compileDebugKotlinAndroid --no-daemon
- GRADLE_USER_HOME=/tmp/codex-gradle-kuiklybase JAVA_HOME=$(/usr/libexec/java_home -v 22) ./gradlew :network:compileKotlinOhosArm64 --no-daemon
- GRADLE_USER_HOME=/tmp/codex-gradle-kuiklybase JAVA_HOME=$(/usr/libexec/java_home -v 22) ./gradlew :network:compileKotlinIosArm64 --no-daemon
- c++ -std=c++17 -fsyntax-only ... curl_wrapper.cpp